### PR TITLE
Per-Module levels

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -116,6 +116,18 @@ defmodule RingLogger do
   @spec configure([server_option]) :: :ok
   defdelegate configure(opts), to: Server
 
+  @doc """
+  Update the Log level for the given module
+
+  Note that `:_` will change the default level all modules
+
+  For example, to make MyModule :warn, while defaulting to :debug:
+  iex> RingLogger.level(MyModule, :warn)
+  iex> RingLogger.level(:_, :debug)
+  """
+  def level(module,level) do
+    Logger.configure_backend(__MODULE__, module_levels: %{ module => level })
+  end
   #
   # Logger backend callbacks
   #

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -123,7 +123,10 @@ defmodule RingLogger do
 
   For example, to make MyModule :warn, while defaulting to :debug:
   iex> RingLogger.level(MyModule, :warn)
+  :ok
+
   iex> RingLogger.level(:_, :debug)
+  :ok
   """
   def level(module,level) do
     Logger.configure_backend(__MODULE__, module_levels: %{ module => level })

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -120,7 +120,7 @@ defmodule RingLogger do
   # Logger backend callbacks
   #
   def init(__MODULE__) do
-    {:ok, init({__MODULE__, []})}
+    init({__MODULE__, []})
   end
 
   def init({__MODULE__, opts}) when is_list(opts) do
@@ -143,7 +143,7 @@ defmodule RingLogger do
   end
 
   def handle_event({level, _gl, {Logger, _, _, _} = msg}, state) do
-    Server.log({level, msg})
+    Server.log({level, msg}, state)
     {:ok, state}
   end
 

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -14,7 +14,8 @@ defmodule RingLogger.Client do
               metadata: nil,
               format: nil,
               level: nil,
-              index: 0
+              index: 0,
+              location: false
   end
 
   @doc """
@@ -41,6 +42,7 @@ defmodule RingLogger.Client do
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string
   * `:level` - The minimum log level to report.
+  * `:location` - Includ the module + function in message
   """
   @spec configure(GenServer.server(), [RingLogger.client_option()]) :: :ok
   def configure(client_pid, config) do
@@ -97,12 +99,21 @@ defmodule RingLogger.Client do
   end
 
   def init(config) do
+    server_env = Application.get_env(:logger, RingLogger, [])
+    client_env = Application.get_env(:logger, __MODULE__, [])
+
+    config =
+      server_env
+      |> Keyword.merge(client_env)
+      |> Keyword.merge(config)
+
     state = %State{
       io: Keyword.get(config, :io, :stdio),
       colors: configure_colors(config),
       metadata: Keyword.get(config, :metadata, []) |> configure_metadata(),
       format: Logger.Formatter.compile(Keyword.get(config, :format)),
-      level: Keyword.get(config, :level, :debug)
+      level: Keyword.get(config, :level, :debug),
+      location: Keyword.get(config, :location, false),
     }
 
     {:ok, state}
@@ -166,6 +177,12 @@ defmodule RingLogger.Client do
   defp format_message({level, {_, msg, ts, md}}, state) do
     metadata = take_metadata(md, state.metadata)
 
+    msg = if state.location do
+            [module_function(md[:module],md[:function]), " : ", msg]
+          else
+            msg
+          end
+
     state.format
     |> Logger.Formatter.format(level, msg, ts, metadata)
     |> color_event(level, state.colors, md)
@@ -223,5 +240,21 @@ defmodule RingLogger.Client do
       item = format_message(msg, state)
       IO.binwrite(state.io, item)
     end
+  end
+
+  defp module_function(nil,_function) do
+    ["iex"]
+  end
+
+  defp module_function(module,function) do
+    mod =
+      case to_string(module) do
+        "Elixir." <> mod -> mod
+        "nil" -> ""
+        binary -> binary
+      end
+
+    fx = to_string(function)
+    [mod,".",fx]
   end
 end

--- a/lib/ring_logger/configuration.ex
+++ b/lib/ring_logger/configuration.ex
@@ -1,0 +1,21 @@
+defmodule RingLogger.Configuration do
+
+  def meet_level?(module_levels, module, level) when is_map(module_levels) do
+    default_level = module_levels
+                    |> Map.get(:_, :debug)
+    module_levels
+    |> Map.get(module, default_level)
+    |> do_meet_level?(level)
+  end
+
+  def meet_level?(nil,_,_) do
+    # Not using module levels
+    true
+  end
+
+  defp do_meet_level?(nil, _level), do: true
+
+  defp do_meet_level?(minimum_level, level) do
+    Logger.compare_levels(level, minimum_level) != :lt
+  end
+end


### PR DESCRIPTION
This adds the ability to filter based on modules (See #5).  

For example:
```elixir
config :logger, RingLogger,
  format: "[$level] $message\n",
  location: true,
  module_levels: %{
    Nerves.Network.Udhcpc => :warn,
    Nerves.Network.Config => :warn,
    :_ => :debug
  }
```

In addition
* Cascade env for RingLogger to RingLogger.Client.  This is useful for setting the `:format` and addresses #6 
*  Adds support for including `Module.function/z` in the message (:location).  This information is included in the meta data, but there is no way to format it using Logger format strings

@fhunleth Originally we talked about filtering in the Client, but we had issues with overwhelming RingLogger, so we switched to filtering before the message is sent to the Server.