### PR TITLE
Fix crash when grep'ing iodata

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -237,7 +237,9 @@ defmodule RingLogger.Client do
   end
 
   defp maybe_print({level, {_, text, _, _}} = msg, r, state) do
-    if meet_level?(level, state.level) && Regex.match?(r, text) do
+    flattened_text = IO.iodata_to_binary(text)
+
+    if meet_level?(level, state.level) && Regex.match?(r, flattened_text) do
       item = format_message(msg, state)
       IO.binwrite(state.io, item)
     end

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -94,6 +94,14 @@ defmodule RingLoggerTest do
     assert message =~ "[debug] Hello"
   end
 
+  test "can grep iodata in log", %{io: io} do
+    Logger.debug(["Hello", ",", ' world'])
+    Logger.debug("World")
+    RingLogger.grep(~r/H..lo/, io: io)
+    assert_receive {:io, message}
+    assert message =~ "[debug] Hello, world"
+  end
+
   test "can tail the log", %{io: io} do
     Logger.debug("Hello")
     :ok = RingLogger.tail(io: io)


### PR DESCRIPTION
Log messages are technically iodata, so they need to be flattened to
normal strings before sending them through Regex.match?/2.