### PR TITLE
Add support for printing location

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ they may be coming from Elixir's default `:console` logger.
 To see log messages as they come in, call `RingLogger.attach()` and
 then to make the log messages stop, call `RingLogger.detach()`. The
 `attach` method takes options if you want to limit the log level, change the
-formatting, etc.
+formatting, etc. The options are documented in `RingLogger.Client`
 
 Here's an example:
 

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -61,6 +61,7 @@ defmodule RingLogger do
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string
   * `:level` - The minimum log level to report.
+  * `:location` - Include the module + function in message
   """
   @spec attach([client_option]) :: :ok
   defdelegate attach(opts \\ []), to: Autoclient

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -14,7 +14,8 @@ defmodule RingLogger.Client do
               metadata: nil,
               format: nil,
               level: nil,
-              index: 0
+              index: 0,
+              location: false
   end
 
   @doc """
@@ -41,6 +42,7 @@ defmodule RingLogger.Client do
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string
   * `:level` - The minimum log level to report.
+  * `:location` - Include the module + function in message
   """
   @spec configure(GenServer.server(), [RingLogger.client_option()]) :: :ok
   def configure(client_pid, config) do
@@ -97,12 +99,21 @@ defmodule RingLogger.Client do
   end
 
   def init(config) do
+    server_env = Application.get_env(:logger, RingLogger, [])
+    client_env = Application.get_env(:logger, __MODULE__, [])
+
+    config =
+      server_env
+      |> Keyword.merge(client_env)
+      |> Keyword.merge(config)
+
     state = %State{
       io: Keyword.get(config, :io, :stdio),
       colors: configure_colors(config),
       metadata: Keyword.get(config, :metadata, []) |> configure_metadata(),
       format: Logger.Formatter.compile(Keyword.get(config, :format)),
-      level: Keyword.get(config, :level, :debug)
+      level: Keyword.get(config, :level, :debug),
+      location: Keyword.get(config, :location, false)
     }
 
     {:ok, state}
@@ -166,6 +177,13 @@ defmodule RingLogger.Client do
   defp format_message({level, {_, msg, ts, md}}, state) do
     metadata = take_metadata(md, state.metadata)
 
+    msg =
+      if state.location do
+        [module_function(md[:module], md[:function]), " : ", msg]
+      else
+        msg
+      end
+
     state.format
     |> Logger.Formatter.format(level, msg, ts, metadata)
     |> color_event(level, state.colors, md)
@@ -225,5 +243,21 @@ defmodule RingLogger.Client do
       item = format_message(msg, state)
       IO.binwrite(state.io, item)
     end
+  end
+
+  defp module_function(nil, _function) do
+    ["iex"]
+  end
+
+  defp module_function(module, function) do
+    mod =
+      case to_string(module) do
+        "Elixir." <> mod -> mod
+        "nil" -> ""
+        binary -> binary
+      end
+
+    fx = to_string(function)
+    [mod, ".", fx]
   end
 end

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -179,7 +179,7 @@ defmodule RingLogger.Client do
 
     msg =
       if state.location do
-        [module_function(md[:module], md[:function]), " : ", msg]
+        [module_function(md[:module], md[:function]), ": ", msg]
       else
         msg
       end

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -31,6 +31,13 @@ defmodule RingLoggerTest do
     assert message =~ "[debug] Hello"
   end
 
+  test "show location", %{io: io} do
+    :ok = RingLogger.attach(io: io, location: true)
+    Logger.debug("Hello")
+    assert_receive {:io, message}
+    assert message =~ "[debug] RingLoggerTest.test show location/1: Hello"
+  end
+
   test "attaching twice doesn't duplicate messages", %{io: io} do
     :ok = RingLogger.attach(io: io)
     :ok = RingLogger.attach(io: io)


### PR DESCRIPTION
This currently isn't possible using standard format string, although it is included in the meta data

```elixir
config :logger, RingLogger
  location: true
```

Will prefix any message string with "module.function/arity : "