### PR TITLE
Add support for custom formatting functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,45 @@ iex> RingLogger.grep(~r/[Nn]eedle/)
 16:55:41.614 [info]  Needle in a haystack
 ```
 
+## Formatting
+
+If you want to use a specific string format with the built in Elixir
+Logger.Formatter, you can pass that as the `:format` option to
+`RingLogger.attach/1`.
+
+If you want to use a custom formatter function, you can pass it through the
+`:format` option to `RingLogger.attach/1` instead.
+
+For example, to print the file and line number of each log message, you could
+define a function as follows:
+
+```elixir
+defmodule CustomFormatter do
+  def format(_level, message, _timestamp, metadata) do
+    "#{message} #{metadata[:file]}:#{metadata[:line]}\n"
+  rescue
+    _ -> message
+  end
+end
+```
+
+and attach to the RingLogger with:
+
+```elixir
+iex> RingLogger.attach(format: {CustomFormatter, :format}, metadata: [:file, :line])
+:ok
+iex> require Logger
+Logger
+iex> Logger.info("Important message!")
+:ok
+Important message! iex:4
+```
+
+Within an application, the `iex:4` would be the source file path and line number.
+
+See https://hexdocs.pm/logger/Logger.html#module-custom-formatting for more
+information about custom formatting.
+
 ## Programmatic usage
 
 It can be useful to get a snapshot of the log when an unexpected event occurs.

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -42,11 +42,13 @@ defmodule RingLogger do
           {:io, term}
           | {:color, term}
           | {:metadata, Logger.metadata()}
-          | {:format, String.t()}
+          | {:format, String.t() | custom_formatter}
           | {:level, Logger.level()}
 
   @typedoc "A tuple holding a raw, unformatted log entry"
   @type entry :: {module(), Logger.level(), Logger.message(), Logger.Formatter.time(), keyword()}
+
+  @typep custom_formatter :: {module, function}
 
   #
   # API

--- a/lib/ring_logger/autoclient.ex
+++ b/lib/ring_logger/autoclient.ex
@@ -5,7 +5,7 @@ defmodule RingLogger.Autoclient do
   Helper module for `RingLogger.Client` to simplify IEx use
 
   If you're a human, call these functions via `RingLogger.*`. If you're a
-  program, call `RingLogger.Client.start_link/1` to start you're own client and
+  program, call `RingLogger.Client.start_link/1` to start your own client and
   call it directly.
   """
 

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -4,6 +4,7 @@ defmodule RingLoggerTest do
 
   import ExUnit.CaptureIO
   require Logger
+  alias RingLogger.TestCustomFormatter
 
   setup do
     {:ok, pid} = RingLogger.TestIO.start(self())
@@ -198,6 +199,17 @@ defmodule RingLoggerTest do
 
   test "can format messages", %{io: io} do
     :ok = RingLogger.attach(io: io, format: "$metadata$message", metadata: [:index])
+
+    Logger.debug("Hello")
+    assert_receive {:io, message}
+    assert message =~ "index=0 Hello"
+    Logger.debug("World")
+    assert_receive {:io, message}
+    assert message =~ "index=1 World"
+  end
+
+  test "can use custom formatter", %{io: io} do
+    :ok = RingLogger.attach(io: io, format: {TestCustomFormatter, :format}, metadata: [:index])
 
     Logger.debug("Hello")
     assert_receive {:io, message}

--- a/test/support/test_custom_formatter.ex
+++ b/test/support/test_custom_formatter.ex
@@ -1,0 +1,5 @@
+defmodule RingLogger.TestCustomFormatter do
+  def format(_level, message, _timestamp, metadata) do
+    "index=#{metadata[:index]} #{message}"
+  end
+end


### PR DESCRIPTION
Resolves #13 

This follows the conventions set by 
https://hexdocs.pm/logger/Logger.html#module-custom-formatting to allow
the `:format` option to accept a `{module, function}` value. If this is
passed instead of a format string, the function will be called instead
of `Logger.Formatter.compile` (on init) and `Logger.Formatter.format`
(on format_message).