### PR TITLE
Provide module level filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ iex> RingLogger.grep(~r/[Nn]eedle/)
 16:55:41.614 [info]  Needle in a haystack
 ```
 
+## Module Level Filtering
+
+If you want to filter a module or modules at a particular level you pass
+a map where the key is the module name and value in the level into the
+`:module_levels` option to `RingLogger.attach/1`.
+
+For example:
+
+```
+iex> RingLogger.attach(module_levels: %{MyModule => :info})
+```
+
+This will ignore all the `:debug` messages from `MyModule`.
+
+Also, it allows for filtering the whole project on a higher level,
+but a particular module, or a subset of modules, to log at a lower
+level like so:
+
+```
+iex> RingLogger.attach(module_levels: %{MyModule => :debug}, level: :warn)
+```
+
+In the example above log messages at the `:debug` level will be logged,
+but every other module will be logging at the `:warn` level.
+
+As a note if the Elixir `Logger` level is set too low you will miss some
+log messages.
+
 ## Formatting
 
 If you want to use a specific string format with the built in Elixir

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -44,6 +44,7 @@ defmodule RingLogger do
           | {:metadata, Logger.metadata()}
           | {:format, String.t() | custom_formatter}
           | {:level, Logger.level()}
+          | {:module_levels, map()}
 
   @typedoc "A tuple holding a raw, unformatted log entry"
   @type entry :: {module(), Logger.level(), Logger.message(), Logger.Formatter.time(), keyword()}
@@ -63,6 +64,7 @@ defmodule RingLogger do
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string
   * `:level` - The minimum log level to report.
+  * `:module_levels` - A map of module to log level for module level logging
   """
   @spec attach([client_option]) :: :ok
   defdelegate attach(opts \\ []), to: Autoclient

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -14,7 +14,8 @@ defmodule RingLogger.Client do
               metadata: nil,
               format: nil,
               level: nil,
-              index: 0
+              index: 0,
+              module_levels: %{}
   end
 
   @doc """
@@ -103,7 +104,8 @@ defmodule RingLogger.Client do
       colors: configure_colors(config),
       metadata: Keyword.get(config, :metadata, []) |> configure_metadata(),
       format: Keyword.get(config, :format) |> configure_formatter(),
-      level: Keyword.get(config, :level, :debug)
+      level: Keyword.get(config, :level, :debug),
+      module_levels: Keyword.get(config, :module_levels, %{})
     }
 
     {:ok, state}
@@ -227,19 +229,38 @@ defmodule RingLogger.Client do
     Logger.Formatter.compile(format)
   end
 
-  defp maybe_print({level, _} = msg, state) do
-    if meet_level?(level, state.level) do
+  defp maybe_print(msg, state) do
+    if should_print?(msg, state) do
       item = format_message(msg, state)
       IO.binwrite(state.io, item)
     end
   end
 
-  defp maybe_print({level, {_, text, _, _}} = msg, r, state) do
+  defp maybe_print({_, {_, text, _, _}} = msg, r, state) do
     flattened_text = IO.iodata_to_binary(text)
 
-    if meet_level?(level, state.level) && Regex.match?(r, flattened_text) do
+    if should_print?(msg, state) && Regex.match?(r, flattened_text) do
       item = format_message(msg, state)
       IO.binwrite(state.io, item)
+    end
+  end
+
+  defp get_module_from_msg({_, {_, _, _, meta}}) do
+    Keyword.get(meta, :module)
+  end
+
+  defp should_print?({level, _} = msg, %State{module_levels: module_levels} = state) do
+    module = get_module_from_msg(msg)
+
+    with module_level when not is_nil(module_level) <- Map.get(module_levels, module),
+         true <- meet_level?(level, module_level) do
+      true
+    else
+      nil ->
+        meet_level?(level, state.level)
+
+      _ ->
+        false
     end
   end
 end


### PR DESCRIPTION
I am opening this PR to start the conversation about getting module level filtering in for RingLogger. I would love feedback. Basically, this adds the ability to:

```
iex> RingLogger.attach(module_levels: %{SomeModule => :info})
```

To allow for `:info` and above logging to take place for this module. 

Also, it allows for filtering the whole project on a higher level, but a particular module, or a subset of modules, to log at a lower level like so:

```
iex> RingLogger.attach(module_levels: %{SomeModule => :debug}, level: :warn)
```

In the example above log messages at the `:debug` level will be logged, but every other module will be logging at the `:warn` level.


This PR does not support doing this at the `config.exs` file, but I can add that in this PR, or make another PR for that if that is a feature that is desired. Just let me know what the thoughts are on that.

Thank you!