### PR TITLE
fix clients can not be fully configured at runtime

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -115,12 +115,8 @@ defmodule RingLogger.Client do
   end
 
   def handle_call({:config, config}, _from, state) do
-    new_io = Keyword.get(config, :io, state.io)
-    new_level = Keyword.get(config, :level, state.level)
-
-    new_state = %State{state | io: new_io, level: new_level}
-
-    {:reply, :ok, new_state}
+    new_config = Keyword.drop(config, [:index])
+    {:reply, :ok, struct(state, new_config)}
   end
 
   def handle_call(:attach, _from, state) do

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -1,0 +1,50 @@
+defmodule RingLogger.Client.Test do
+  use ExUnit.Case, async: false
+  alias RingLogger.Client
+
+  describe "configure a client at runtime" do
+    setup do
+      {:ok, client} = Client.start_link()
+      {:ok, %{client: client}}
+    end
+
+    test "configure level", %{client: client} do
+      Client.configure(client, level: :error)
+      assert :error == :sys.get_state(client).level
+    end
+
+    test "configure colors", %{client: client} do
+      colors = %{
+        debug: :red,
+        info: :normal,
+        warn: :cyan,
+        error: :yellow,
+        enabled: IO.ANSI.enabled?()
+      }
+
+      Client.configure(client, colors: colors)
+
+      assert colors == :sys.get_state(client).colors
+    end
+
+    test "configure metadata", %{client: client} do
+      Client.configure(client, metadata: %{foo: :bar})
+      assert %{foo: :bar} == :sys.get_state(client).metadata
+    end
+
+    test "configure io", %{client: client} do
+      Client.configure(client, io: :baz)
+      assert :baz == :sys.get_state(client).io
+    end
+
+    test "configure format", %{client: client} do
+      Client.configure(client, format: "Hello")
+      assert "Hello" == :sys.get_state(client).format
+    end
+
+    test "cannot configure index", %{client: client} do
+      Client.configure(client, index: :foo)
+      refute :foo == :sys.get_state(client).index
+    end
+  end
+end


### PR DESCRIPTION
I noticed that `RingLogger.Client.configure/2` only configured the `:io` and `:level` fields, so I was not able to configure other fields. I experienced this when I would attach and detach and then attach again with a different configuration. As reattaching tries to update the configuration if needed. This should allow all config fields to be configurable as advertised in the docs and type specs.