### PR TITLE
Support filtering out all log messages using :none

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ iex> RingLogger.attach(module_levels: %{MyModule => :debug}, level: :warn)
 ```
 
 In the example above log messages at the `:debug` level will be logged,
-but every other module will be logging at the `:warn` level.
+but every other module will be logging at the `:warn` level. You can also
+turn off a module's logging completely by specifying `:none`.
 
 As a note if the Elixir `Logger` level is set too low you will miss some
 log messages.

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -64,7 +64,8 @@ defmodule RingLogger do
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string
   * `:level` - The minimum log level to report.
-  * `:module_levels` - A map of module to log level for module level logging
+  * `:module_levels` - A map of module to log level for module level logging. For example,
+    %{MyModule => :error, MyOtherModule => :none}
   """
   @spec attach([client_option]) :: :ok
   defdelegate attach(opts \\ []), to: Autoclient

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -196,6 +196,7 @@ defmodule RingLogger.Client do
   end
 
   defp meet_level?(_lvl, nil), do: true
+  defp meet_level?(_lvl, :none), do: false
 
   defp meet_level?(lvl, min) do
     Logger.compare_levels(lvl, min) != :lt

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -230,6 +230,19 @@ defmodule RingLoggerTest do
     assert_receive {:io, _message}
   end
 
+  test "can filter all levels by module", %{io: io} do
+    :ok = RingLogger.attach(io: io, module_levels: %{__MODULE__ => :none})
+
+    Logger.info("foo")
+    refute_receive {:io, _message}
+    Logger.debug("bar")
+    refute_receive {:io, _message}
+    Logger.warn("baz")
+    refute_receive {:io, _message}
+    Logger.error("uhh")
+    refute_receive {:io, _message}
+  end
+
   test "can filter module level to print lower than logger level", %{io: io} do
     :ok = RingLogger.attach(io: io, module_levels: %{__MODULE__ => :debug}, level: :warn)
 


### PR DESCRIPTION
This lets you completely turn off logs from modules by specifying
`:none`.