### PR TITLE
Print in the context of the caller

### DIFF
--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -141,11 +141,10 @@ defmodule RingLoggerTest do
     |> handshake_log(:debug, "Bar")
 
     :ok = RingLogger.next()
-    assert_receive {:io, message1}
-    assert_receive {:io, message2}
+    assert_receive {:io, messages}
 
-    assert message1 =~ "[debug] Foo"
-    assert message2 =~ "[debug] Bar"
+    assert messages =~ "[debug] Foo"
+    assert messages =~ "[debug] Bar"
   end
 
   test "can reset to the beginning", %{io: io} do
@@ -165,7 +164,7 @@ defmodule RingLoggerTest do
   test "can tail the log", %{io: io} do
     :ok = RingLogger.attach(io: io)
     :ok = RingLogger.tail(io: io)
-    refute_receive {:io, _}
+    assert_receive {:io, ""}
 
     handshake_log(io, :debug, "Hello")
     :ok = RingLogger.tail()
@@ -178,17 +177,17 @@ defmodule RingLoggerTest do
 
     :ok = RingLogger.tail()
 
-    assert_receive {:io, message1}
-    assert_receive {:io, message2}
-    assert_receive {:io, message3}
+    assert_receive {:io, messages}
 
-    assert message1 =~ "[debug] Hello"
-    assert message2 =~ "[debug] Foo"
-    assert message3 =~ "[debug] Bar"
+    assert messages =~ "[debug] Hello"
+    assert messages =~ "[debug] Foo"
+    assert messages =~ "[debug] Bar"
 
     :ok = RingLogger.tail(1)
     assert_receive {:io, message}
     assert message =~ "[debug] Bar"
+    refute message =~ "[debug] Hello"
+    refute message =~ "[debug] Foo"
   end
 
   test "can get buffer", %{io: io} do


### PR DESCRIPTION
This fixes the GenServer timeouts when next, tail, and grep have a lot
to print over a slow connection. Now if anything goes wrong or takes
unexpectantly long, it will come from an IO.binwrite call in the
caller's context. This had two unintended benefits:

1. One call to IO.binwrite. Apparently I missed that I had iodata
   before. This removes calls to Enum.each.
2. grep now grep's the entire log message instead of just the message
   part. You can grep on timestamps and debug level now.

The downside to #1 is that it had an effect on the unit tests since all
output comes at once. I updated the unit tests to expect this.