### PR TITLE
Add option for specifying a pager

### DIFF
--- a/lib/ring_logger/autoclient.ex
+++ b/lib/ring_logger/autoclient.ex
@@ -12,9 +12,9 @@ defmodule RingLogger.Autoclient do
   @doc """
   Attach to the logger and print messages as they come in.
   """
-  def attach(config \\ []) do
+  def attach(opts \\ []) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(config),
+         pid <- maybe_create_client(opts),
          do: Client.attach(pid)
   end
 
@@ -42,37 +42,37 @@ defmodule RingLogger.Autoclient do
   @doc """
   Print the log messages since the previous time this was called.
   """
-  def next(config \\ []) do
+  def next(opts \\ []) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(config),
-         do: Client.next(pid)
+         pid <- maybe_create_client(opts),
+         do: Client.next(pid, opts)
   end
 
   @doc """
   Print the most recent log messages.
   """
-  def tail(n, config) do
+  def tail(n, opts) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(config),
-         do: Client.tail(pid, n)
+         pid <- maybe_create_client(opts),
+         do: Client.tail(pid, n, opts)
   end
 
   @doc """
   Run a regular expression on each entry in the log and print out the matchers.
   """
-  def grep(regex, config \\ []) do
+  def grep(regex, opts \\ []) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(config),
-         do: Client.grep(pid, regex)
+         pid <- maybe_create_client(opts),
+         do: Client.grep(pid, regex, opts)
   end
 
   @doc """
   Reset the index used to keep track of the position in the log for `tail/1` so
   that the next call to `tail/1` starts back at the oldest entry.
   """
-  def reset(config \\ []) do
+  def reset(opts \\ []) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(config),
+         pid <- maybe_create_client(opts),
          do: Client.reset(pid)
   end
 
@@ -81,7 +81,7 @@ defmodule RingLogger.Autoclient do
   """
   def format(message) do
     with :ok <- check_server_started(),
-         pid <- maybe_create_client(),
+         pid <- maybe_create_client([]),
          do: Client.format(pid, message)
   end
 
@@ -123,16 +123,16 @@ defmodule RingLogger.Autoclient do
     end
   end
 
-  defp maybe_create_client(config \\ []) do
+  defp maybe_create_client(opts) do
     case get_client_pid() do
       nil ->
-        {:ok, pid} = Client.start_link(config)
+        {:ok, pid} = Client.start_link(opts)
         Process.put(:ring_logger_client, pid)
         pid
 
       pid ->
         # Update the configuration if the user changed something
-        Client.configure(pid, config)
+        Client.configure(pid, opts)
         pid
     end
   end

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -67,20 +67,32 @@ defmodule RingLogger.Client do
 
   @doc """
   Get the last n messages.
+
+  Supported options:
+
+  * `:pager` - an optional 2-arity function that takes an IO device and what to print
   """
   @spec tail(GenServer.server(), non_neg_integer()) :: :ok | {:error, term()}
-  def tail(client_pid, n) do
+  def tail(client_pid, n, opts \\ []) do
     {io, to_print} = GenServer.call(client_pid, {:tail, n})
-    IO.binwrite(io, to_print)
+
+    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager.(io, to_print)
   end
 
   @doc """
   Get the next set of the messages in the log.
+
+  Supported options:
+
+  * `:pager` - an optional 2-arity function that takes an IO device and what to print
   """
-  @spec next(GenServer.server()) :: :ok | {:error, term()}
-  def next(client_pid) do
+  @spec next(GenServer.server(), keyword()) :: :ok | {:error, term()}
+  def next(client_pid, opts \\ []) do
     {io, to_print} = GenServer.call(client_pid, :next)
-    IO.binwrite(io, to_print)
+
+    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager.(io, to_print)
   end
 
   @doc """
@@ -102,11 +114,17 @@ defmodule RingLogger.Client do
 
   @doc """
   Run a regular expression on each entry in the log and print out the matchers.
+
+  Supported options:
+
+  * `:pager` - an optional 2-arity function that takes an IO device and what to print
   """
-  @spec grep(GenServer.server(), Regex.t()) :: :ok | {:error, term()}
-  def grep(client_pid, regex) do
+  @spec grep(GenServer.server(), Regex.t(), keyword()) :: :ok | {:error, term()}
+  def grep(client_pid, regex, opts \\ []) do
     {io, to_print} = GenServer.call(client_pid, {:grep, regex})
-    IO.binwrite(io, to_print)
+
+    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager.(io, to_print)
   end
 
   def init(config) do


### PR DESCRIPTION
This removes the hardcoded printout and allows users to pass a custom
pager.