### PR TITLE
Passing invalid regex should return an error

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -121,10 +121,14 @@ defmodule RingLogger.Client do
   """
   @spec grep(GenServer.server(), Regex.t(), keyword()) :: :ok | {:error, term()}
   def grep(client_pid, regex, opts \\ []) do
-    {io, to_print} = GenServer.call(client_pid, {:grep, regex})
+    if Regex.regex?(regex) do
+      {io, to_print} = GenServer.call(client_pid, {:grep, regex})
 
-    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
-    pager.(io, to_print)
+      pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+      pager.(io, to_print)
+    else
+      {:error, :invalid_regex}
+    end
   end
 
   def init(config) do

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -128,6 +128,10 @@ defmodule RingLoggerTest do
     assert message =~ "[debug] Hello, world"
   end
 
+  test "invalid regex returns error", %{io: io} do
+    assert {:error, _} = RingLogger.grep("", io: io)
+  end
+
   test "can next the log", %{io: io} do
     :ok = RingLogger.attach(io: io)
     handshake_log(io, :debug, "Hello")


### PR DESCRIPTION
Calling `RingLogger.grep/1` with a value that is not regex causes an unplesant error and kills the autoclient process which inturn kills the shell process.
```
iex(1)> RingLogger.grep "eth0"
** (EXIT from #PID<0.179.0>) shell process exited with reason: an exception was raised:
    ** (FunctionClauseError) no function clause matching in Regex.match?/2
        (elixir) lib/regex.ex:236: Regex.match?("eth0", "\e[36m\n10:18:28.298 [debug] 1\n\e[0m")
        (elixir) lib/enum.ex:2898: Enum.filter_list/2
        (ring_logger) lib/ring_logger/client.ex:199: RingLogger.Client.handle_call/3
        (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
        (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

This PR makes it safe by validating the regex before calling into the client server.
```
iex(1)> RingLogger.grep "eth0"
{:error, :invalid_regex}
```