### PR TITLE
Support filtering at the application level

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ iex> RingLogger.grep(~r/[Nn]eedle/)
 16:55:41.614 [info]  Needle in a haystack
 ```
 
-## Module Level Filtering
+## Module and Application Level Filtering
 
 If you want to filter a module or modules at a particular level you pass a map
 where the key is the module name and value in the level into the
@@ -145,6 +145,24 @@ iex> RingLogger.attach(module_levels: %{MyModule => :debug}, level: :warn)
 In the example above log messages at the `:debug` level will be logged, but
 every other module will be logging at the `:warn` level. You can also turn off a
 module's logging completely by specifying `:none`.
+
+Additionally, you can specify the same options at the application level to
+disable logging for all its modules using the `:application_levels` option
+with OTP application names as the key:
+
+```elixir
+iex> RingLogger.attach(application_levels: %{my_app: :info})
+```
+
+`module_levels` takes precedence in the case of including both module and
+application level filtering:
+
+```elixir
+iex> RingLogger.attach(application_levels: %{my_app: :info}, module_levels: %{MyApp.Important => :debug})
+```
+
+In the above example, all modules of `:my_app` with have a level of `:info` except
+for `MyApp.Important`, which will have a level of `:debug`.
 
 As a note if the Elixir `Logger` level is set too low you will miss some log
 messages.

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -49,6 +49,7 @@ defmodule RingLogger do
           | {:format, String.t() | custom_formatter}
           | {:level, Logger.level()}
           | {:module_levels, map()}
+          | {:application_levels, map()}
 
   @typedoc "A tuple holding a raw, unformatted log entry"
   @type entry ::
@@ -73,6 +74,9 @@ defmodule RingLogger do
     application's `:level` setting filters log messages prior to `RingLogger`.
   * `:module_levels` - a map of log level overrides per module. For example,
     %{MyModule => :error, MyOtherModule => :none}
+  * `:application_levels` - a map of log level overrides per application. For example,
+    %{:my_app => :error, :my_other_app => :none}. Note log levels set in `:module_levels`
+    will take precendence.
   """
   @spec attach([client_option]) :: :ok
   defdelegate attach(opts \\ []), to: Autoclient

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -46,5 +46,34 @@ defmodule RingLogger.Client.Test do
       Client.configure(client, index: :foo)
       refute :foo == :sys.get_state(client).index
     end
+
+    test "configures with module_levels key", %{client: client} do
+      module_levels = %{RingLogger => :info}
+
+      Client.configure(client, module_levels: module_levels)
+
+      assert :sys.get_state(client).module_levels == module_levels
+    end
+
+    test "configures module_levels from application_levels", %{client: client} do
+      Client.configure(client, application_levels: %{ring_logger: :debug})
+
+      module_levels = :sys.get_state(client).module_levels
+
+      assert module_levels[RingLogger] == :debug
+      assert module_levels[RingLogger.Client] == :debug
+    end
+
+    test "configuring module_level overwrites application_levels", %{client: client} do
+      Client.configure(client,
+        application_levels: %{ring_logger: :debug},
+        module_levels: %{RingLogger => :info}
+      )
+
+      module_levels = :sys.get_state(client).module_levels
+
+      assert module_levels[RingLogger] == :info
+      assert module_levels[RingLogger.Client] == :debug
+    end
   end
 end


### PR DESCRIPTION
Allows you to filter logging for an entire OTP app instead of specifying every module level for that app. (Very helpful for calming noisy apps)

This will ease @fhunleth sanity..