### PR TITLE
Support client options in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ config :logger, backends: [RingLogger]
 
 # Set the number of messages to hold in the circular buffer
 config :logger, RingLogger, max_size: 1024
+
+# You can also configure RingLogger.Client options to be used
+# with every client by default
+config :ring_logger,
+  application_levels: %{my_app: :error},
+  color: [debug: :yellow],
+  level: :debug
 ```
 
 Or you can start the backend manually by running the following:

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -157,16 +157,7 @@ defmodule RingLogger.Client do
 
   @impl true
   def init(config) do
-    state = %State{
-      io: Keyword.get(config, :io, :stdio),
-      colors: configure_colors(config),
-      metadata: Keyword.get(config, :metadata, []) |> configure_metadata(),
-      format: Keyword.get(config, :format) |> configure_formatter(),
-      level: Keyword.get(config, :level, :debug),
-      module_levels: configure_module_levels(config)
-    }
-
-    {:ok, state}
+    {:ok, configure_state(config)}
   end
 
   @impl true
@@ -177,11 +168,7 @@ defmodule RingLogger.Client do
 
   @impl true
   def handle_call({:config, config}, _from, state) do
-    new_config =
-      Keyword.drop(config, [:index])
-      |> Keyword.put(:module_levels, configure_module_levels(config))
-
-    {:reply, :ok, struct(state, new_config)}
+    {:reply, :ok, configure_state(config)}
   end
 
   @impl true
@@ -281,6 +268,20 @@ defmodule RingLogger.Client do
 
   defp apply_format(format, level, msg, ts, metadata) do
     Logger.Formatter.format(format, level, msg, ts, metadata)
+  end
+
+  defp configure_state(config) do
+    defaults = Application.get_all_env(:ring_logger)
+    config = Keyword.merge(defaults, config)
+
+    %State{
+      io: Keyword.get(config, :io, :stdio),
+      colors: configure_colors(config),
+      metadata: Keyword.get(config, :metadata, []) |> configure_metadata(),
+      format: Keyword.get(config, :format) |> configure_formatter(),
+      level: Keyword.get(config, :level, :debug),
+      module_levels: configure_module_levels(config)
+    }
   end
 
   defp configure_metadata(:all), do: :all


### PR DESCRIPTION
Adds ability to specify default RingLogger.Client options in `config.exs`