### PR TITLE
Print summary at end of RingLogger.next/1

### DIFF
--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -269,7 +269,7 @@ defmodule RingLoggerTest do
 
     assert_receive {:io, messages}
 
-    assert messages =~ "Got 107 characters"
+    assert messages =~ "Got 139 characters"
   end
 
   test "tail supports passing a custom pager", %{io: io} do


### PR DESCRIPTION
Before if no messages were printed, it could either be due to there not
being any messages or them all being filtered away. `RingLogger.next/1`
now prints summaries like the following:

```
iex> RingLogger.next
All 72 new messages filtered out.
```

```
iex> RingLogger.next
No new messages.
```

```
iex> RingLogger.next

...

1 out of 18 new messages shown.
```