### PR TITLE
CI: Elixir 1.12/OTP 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_10_otp_23:
+  build_elixir_1_12_otp_24:
     docker:
-      - image: erlang:23.0.3
+      - image: erlang:24.0
         environment:
-          ELIXIR_VERSION: 1.10.4-otp-23
+          ELIXIR_VERSION: 1.12.0-rc.1-otp-23
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -53,6 +53,21 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_11_otp_23:
+    docker:
+      - image: erlang:23.0.3
+        environment:
+          ELIXIR_VERSION: 1.10.4-otp-23
+          LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_10_otp_22:
     docker:
       - image: erlang:22.3.4.1
@@ -66,7 +81,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_9_otp_22:
@@ -82,7 +96,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_8_otp_22:
@@ -98,7 +111,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_7_otp_21:
@@ -114,7 +126,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_6_otp_20:
@@ -130,7 +141,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_5_otp_20:
@@ -146,7 +156,6 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
-      - run: mix compile
       - run: MIX_ENV=test mix compile
       - run: mix test
 
@@ -170,7 +179,9 @@ workflows:
   version: 2
   build_test:
     jobs:
-      - build_elixir_1_10_otp_23:
+      - build_elixir_1_12_otp_24:
+          context: org-global
+      - build_elixir_1_11_otp_23:
           context: org-global
       - build_elixir_1_10_otp_22:
           context: org-global

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+# Always warning as errors
+if Version.match?(System.version(), "~> 1.10") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 ExUnit.start()


### PR DESCRIPTION
- Force warnings as errors in tests
- Add Elixir 1.12/OTP 24 build to Circle config
