### PR TITLE
Erlang 24 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     docker:
       - image: erlang:24.0
         environment:
-          ELIXIR_VERSION: 1.12.0-rc.1-otp-23
+          ELIXIR_VERSION: 1.12.0-rc.1-otp-24
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -367,7 +367,7 @@ defmodule RingLogger.Client do
 
   defp color_event(data, level, %{enabled: true} = colors, md) do
     color = md[:ansi_color] || Map.fetch!(colors, level)
-    [IO.ANSI.format_fragment(color, true), data | IO.ANSI.reset()]
+    [IO.ANSI.format_fragment(color, true), data, IO.ANSI.reset()]
   end
 
   defp configure_formatter({mod, fun}), do: {mod, fun}


### PR DESCRIPTION
- CI: Use OTP-24 built version of Elixir 1.12
- Fix OTP 24 Dialyzer warning
