### PR TITLE
CI: org-global isn't needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,21 +179,12 @@ workflows:
   version: 2
   build_test:
     jobs:
-      - build_elixir_1_12_otp_24:
-          context: org-global
-      - build_elixir_1_11_otp_23:
-          context: org-global
-      - build_elixir_1_10_otp_22:
-          context: org-global
-      - build_elixir_1_9_otp_22:
-          context: org-global
-      - build_elixir_1_8_otp_22:
-          context: org-global
-      - build_elixir_1_7_otp_21:
-          context: org-global
-      - build_elixir_1_6_otp_20:
-          context: org-global
-      - build_elixir_1_5_otp_20:
-          context: org-global
-      - build_elixir_1_4_otp_19:
-          context: org-global
+      - build_elixir_1_12_otp_24
+      - build_elixir_1_11_otp_23
+      - build_elixir_1_10_otp_22
+      - build_elixir_1_9_otp_22
+      - build_elixir_1_8_otp_22
+      - build_elixir_1_7_otp_21
+      - build_elixir_1_6_otp_20
+      - build_elixir_1_5_otp_20
+      - build_elixir_1_4_otp_19


### PR DESCRIPTION
CircleCI won't build PRs from forks and it looks like it is due to not
being able to pass secrets. No secrets are needed to built RingLogger,
so remove references to the org-global context.
