### PR TITLE
Allow full configuring under logger application

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ config :logger, backends: [RingLogger]
 # Set the number of messages to hold in the circular buffer
 config :logger, RingLogger, max_size: 1024
 
-# You can also configure RingLogger.Client options to be used
+# You can also configure `RingLogger.Client` options to be used
 # with every client by default
-config :ring_logger,
+config :logger, RingLogger,
   application_levels: %{my_app: :error},
-  color: [debug: :yellow],
+  colors: [debug: :yellow],
   level: :debug
 ```
 

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -289,7 +289,7 @@ defmodule RingLogger.Client do
   end
 
   defp configure_state(config, state \\ %State{}) do
-    defaults = Application.get_all_env(:ring_logger)
+    defaults = Application.get_env(:logger, RingLogger)
 
     config =
       Keyword.merge(defaults, config)

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -289,7 +289,7 @@ defmodule RingLogger.Client do
   end
 
   defp configure_state(config, state \\ %State{}) do
-    defaults = Application.get_env(:logger, RingLogger)
+    defaults = build_defaults()
 
     config =
       Keyword.merge(defaults, config)
@@ -299,6 +299,34 @@ defmodule RingLogger.Client do
     config = Keyword.put(config, :module_levels, configure_module_levels(config))
 
     struct(state, config)
+  end
+
+  defp build_defaults do
+    deprecated_defaults = Application.get_all_env(:ring_logger)
+    defaults = Application.get_env(:logger, RingLogger, [])
+    merge_deprecated_defaults(deprecated_defaults, defaults)
+  end
+
+  defp merge_deprecated_defaults([], defaults), do: defaults
+
+  defp merge_deprecated_defaults(deprecated_defaults, defaults) do
+    message = """
+    Setting RingLogger configuration under `:ring_logger` is deprecated. Instead configuration should be set under :logger, RingLogger
+
+    In your config.exs or other configuration file change:
+
+        config :ring_logger,
+          <configurations>
+
+    To:
+
+        config :logger, RingLogger,
+          <configurations>
+    """
+
+    IO.warn(message)
+
+    Keyword.merge(deprecated_defaults, defaults)
   end
 
   defp configure_option({:colors, colors}) do

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -106,9 +106,9 @@ defmodule RingLogger.Client.Test do
   end
 
   @tag application_envs: [
-    ring_logger: [colors: %{debug: :green, error: :blue}],
-    logger: [{RingLogger, [colors: %{debug: :cyan}]}]
-  ]
+         ring_logger: [colors: %{debug: :green, error: :blue}],
+         logger: [{RingLogger, [colors: %{debug: :cyan}]}]
+       ]
   test "non-deprecated config override deprecated config" do
     # Note: `error: :blue` in configuration will be overwritten because maps are not deep merged
     ExUnit.CaptureIO.capture_io(:stderr, fn ->

--- a/test/support/application_env_helpers.ex
+++ b/test/support/application_env_helpers.ex
@@ -8,7 +8,8 @@ defmodule RingLogger.ApplicationEnvHelpers do
   @tag application_envs: [ring_logger: [colors: %{debug: :green, error: :blue}]]
   ```
   """
-  def with_application_env(%{application_envs: application_envs} = context, on_exit) when is_function(on_exit, 1) do
+  def with_application_env(%{application_envs: application_envs} = context, on_exit)
+      when is_function(on_exit, 1) do
     if context.async, do: raise("Not compatible with `async: true`")
 
     for {app, envs} <- application_envs do

--- a/test/support/application_env_helpers.ex
+++ b/test/support/application_env_helpers.ex
@@ -14,15 +14,23 @@ defmodule RingLogger.ApplicationEnvHelpers do
 
     for {app, envs} <- application_envs do
       original_envs = Application.get_all_env(app)
-      Application.put_all_env([{app, envs}])
+      put_all_env([{app, envs}])
 
       on_exit.(fn ->
         # We need to delete all the existing env because `Application.put_all_env` does a deep merge
         for {key, _val} <- Application.get_all_env(app), do: Application.delete_env(app, key)
-        Application.put_all_env([{app, original_envs}])
+        put_all_env([{app, original_envs}])
       end)
     end
   end
 
   def with_application_env(_context, _on_exit), do: :ok
+
+  # `Application.put_all_env/2` is not availble until Elixir 1.9
+  defp put_all_env(application_envs) do
+    for {app, envs} <- application_envs,
+        {key, val} <- envs do
+      Application.put_env(app, key, val)
+    end
+  end
 end

--- a/test/support/application_env_helpers.ex
+++ b/test/support/application_env_helpers.ex
@@ -1,0 +1,27 @@
+defmodule RingLogger.ApplicationEnvHelpers do
+  @doc """
+  Set application env for one test, then resets it after
+
+  Add the following tag to set the configuration for `:ring_logger`:
+
+  ```
+  @tag application_envs: [ring_logger: [colors: %{debug: :green, error: :blue}]]
+  ```
+  """
+  def with_application_env(%{application_envs: application_envs} = context, on_exit) when is_function(on_exit, 1) do
+    if context.async, do: raise("Not compatible with `async: true`")
+
+    for {app, envs} <- application_envs do
+      original_envs = Application.get_all_env(app)
+      Application.put_all_env([{app, envs}])
+
+      on_exit.(fn ->
+        # We need to delete all the existing env because `Application.put_all_env` does a deep merge
+        for {key, _val} <- Application.get_all_env(app), do: Application.delete_env(app, key)
+        Application.put_all_env([{app, original_envs}])
+      end)
+    end
+  end
+
+  def with_application_env(_context, _on_exit), do: :ok
+end


### PR DESCRIPTION
Currently when `Logger.configure_backend` is called the configuration is stored under `:logger, RingLogger` but the initial configuration was still being read from `:ring_logger`

Also the `colors` configuration in the documentation had a typo