### PR TITLE
Fix setting colors enabled

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -303,7 +303,11 @@ defmodule RingLogger.Client do
 
   defp build_defaults do
     deprecated_defaults = Application.get_all_env(:ring_logger)
-    defaults = Application.get_env(:logger, RingLogger, [])
+
+    defaults =
+      Application.get_env(:logger, RingLogger, [])
+      |> Keyword.put_new(:colors, [])
+
     merge_deprecated_defaults(deprecated_defaults, defaults)
   end
 


### PR DESCRIPTION
The default for outputting color is determined by `IO.ANSI.enabled?`, but it
is applied in the `%RingLogger.Client.State{}` struct which is evaluated at
compile time so it will always be `false` and remove the color output.

This change forces in a `:colors` option key when building defaults if it
was not already present (which is normally the case). This will then cause
the config check to go through the configuring colors option which evaluates
`IO.ANSI.enabled?` at runtime for more accurate settings for the prints.