### PR TITLE
Support `:before` and `:after` options in grep

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -145,6 +145,8 @@ defmodule RingLogger do
 
   * Options from `attach/1`
   * `:pager` - a function for printing log messages to the console. Defaults to `IO.binwrite/2`.
+  * `:before` - Number of lines before the match to include
+  * `:after` - NUmber of lines after the match to include
   """
   @spec grep(Regex.t() | String.t(), [client_option]) :: :ok | {:error, term()}
   defdelegate grep(regex_or_string, opts \\ []), to: Autoclient


### PR DESCRIPTION
`:before` and `:after` options can be used with grep to include more
lines before/after the match. Helpful for cases where you might want to
see a little more data in series but don't know exact search terms.

Mimics `-A` and `-B` options of `grep`