### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_12_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: erlang:24.0
+      - image: erlang:25.0
         environment:
-          ELIXIR_VERSION: 1.12.1-otp-24
+          ELIXIR_VERSION: 1.13.4-otp-25
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -52,6 +52,21 @@ jobs:
           paths:
             - _build
             - deps
+
+  build_elixir_1_12_otp_24:
+    docker:
+      - image: erlang:24.3.4
+        environment:
+          ELIXIR_VERSION: 1.12.3-otp-24
+          LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix test
 
   build_elixir_1_11_otp_23:
     docker:
@@ -179,6 +194,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_22

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -78,13 +78,13 @@ defmodule RingLogger do
     %{:my_app => :error, :my_other_app => :none}. Note log levels set in `:module_levels`
     will take precedence.
   """
-  @spec attach([client_option]) :: :ok
+  @spec attach([client_option]) :: :ok | {:error, :no_client}
   defdelegate attach(opts \\ []), to: Autoclient
 
   @doc """
   Fetch the current configuration for the attached client
   """
-  @spec config() :: [client_option()]
+  @spec config() :: [client_option()] | {:error, :no_client}
   defdelegate config(), to: Autoclient
 
   @doc """
@@ -155,7 +155,7 @@ defmodule RingLogger do
   Helper method for formatting log messages per the current client's
   configuration.
   """
-  @spec format(entry()) :: :ok
+  @spec format(entry()) :: :ok | {:error, :no_client}
   defdelegate format(message), to: Autoclient
 
   @doc """
@@ -192,6 +192,9 @@ defmodule RingLogger do
     case Server.start_link(opts) do
       {:ok, _pid} ->
         {:ok, configure(opts)}
+
+      err when is_atom(err) ->
+        {:error, err}
 
       error ->
         error

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule RingLogger.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling]
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling]
     ]
   end
 end


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions