### PR TITLE
Fix unicode chardata support

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -242,6 +242,6 @@ defmodule RingLogger do
   end
 
   defp flatten({mod, msg, ts, md}) do
-    {mod, IO.iodata_to_binary(msg), ts, md}
+    {mod, IO.chardata_to_string(msg), ts, md}
   end
 end

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -244,7 +244,7 @@ defmodule RingLogger.Client do
       for {message, i} <- Enum.with_index(Server.get(0, 0)),
           should_print?(message, state),
           formatted = format_message(message, state),
-          bin = IO.iodata_to_binary(formatted),
+          bin = IO.chardata_to_string(formatted),
           do: {bin, Regex.match?(regex, bin), i}
 
     extras = determine_extra_grep_lines(formatted_buff, opts)


### PR DESCRIPTION
Unicode charlist crashes RingLogger. Logger's messages are `:unicode.chardata` not `iodata`.

```elixir
Logger.debug ~c"Cześć!"
```