### PR TITLE
Replace more incorrect uses of iodata_to_binary

### DIFF
--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -37,7 +37,7 @@ defmodule RingLoggerTest do
     assert_receive {:io, msg}
     assert String.contains?(msg, to_string(level))
 
-    flattened_message = IO.iodata_to_binary(message)
+    flattened_message = IO.chardata_to_string(message)
     assert String.contains?(msg, flattened_message)
     io
   end
@@ -298,7 +298,7 @@ defmodule RingLoggerTest do
     :ok =
       RingLogger.next(
         pager: fn device, msg ->
-          IO.write(device, "Got #{String.length(IO.iodata_to_binary(msg))} characters")
+          IO.write(device, "Got #{String.length(IO.chardata_to_string(msg))} characters")
         end
       )
 
@@ -318,7 +318,7 @@ defmodule RingLoggerTest do
     :ok =
       RingLogger.tail(2,
         pager: fn device, msg ->
-          IO.write(device, "Got #{String.length(IO.iodata_to_binary(msg))} characters")
+          IO.write(device, "Got #{String.length(IO.chardata_to_string(msg))} characters")
         end
       )
 
@@ -338,7 +338,7 @@ defmodule RingLoggerTest do
     :ok =
       RingLogger.grep(~r/debug/,
         pager: fn device, msg ->
-          IO.write(device, "Got #{String.length(IO.iodata_to_binary(msg))} characters")
+          IO.write(device, "Got #{String.length(IO.chardata_to_string(msg))} characters")
         end
       )
 

--- a/test/stress_test.exs
+++ b/test/stress_test.exs
@@ -36,7 +36,7 @@ defmodule StressTest do
     assert_receive {:io, msg}
     assert String.contains?(msg, to_string(level))
 
-    flattened_message = IO.iodata_to_binary(message)
+    flattened_message = IO.chardata_to_string(message)
     assert String.contains?(msg, flattened_message)
     io
   end


### PR DESCRIPTION
This didn't affect the results of any tests since the inputs are limited
to ASCII characters.
