### PR TITLE
Fix unit tests for Elixir 1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,11 @@ install_elixir: &install_elixir
       unzip -d /usr/local/elixir v$ELIXIR_VERSION.zip
       echo 'export PATH=/usr/local/elixir/bin:$PATH' >> $BASH_ENV
 
-install_hex_rebar: &install_hex_rebar
+install_hex: &install_hex
   run:
-    name: Install hex and rebar
+    name: Install hex
     command: |
       mix local.hex --force
-      mix local.rebar --force
 
 install_system_deps: &install_system_deps
   run:
@@ -37,7 +36,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - restore_cache:
           keys:
             - v1-mix-cache-{{ checksum "mix.lock" }}
@@ -64,7 +63,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -79,7 +78,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -94,7 +93,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -109,7 +108,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -124,7 +123,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -139,7 +138,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -154,7 +153,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -169,7 +168,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: mix test
 
@@ -184,7 +183,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: MIX_ENV=test mix compile
       - run: mix test
@@ -200,7 +199,7 @@ jobs:
       - checkout
       - <<: *install_system_deps
       - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_hex
       - run: mix deps.get
       - run: MIX_ENV=test mix compile
       - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_13_otp_25:
+  build_elixir_1_14_otp_25:
     docker:
-      - image: erlang:25.0
+      - image: erlang:25.1.1
         environment:
-          ELIXIR_VERSION: 1.13.4-otp-25
+          ELIXIR_VERSION: 1.14.0-otp-25
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -52,6 +52,21 @@ jobs:
           paths:
             - _build
             - deps
+
+  build_elixir_1_13_otp_25:
+    docker:
+      - image: erlang:25
+        environment:
+          ELIXIR_VERSION: 1.13.4-otp-25
+          LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix test
 
   build_elixir_1_12_otp_24:
     docker:
@@ -194,6 +209,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_14_otp_25
       - build_elixir_1_13_otp_25
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -4,6 +4,9 @@ defmodule RingLogger.Client.Test do
 
   setup do
     {:ok, client} = Client.start_link()
+    # Elixir 1.4 changed the default pattern (removed $levelpad) so hardcode a default
+    # pattern here
+    Client.configure(client, format: "\n$time $metadata[$level] $message\n")
     {:ok, %{client: client}}
   end
 
@@ -85,7 +88,7 @@ defmodule RingLogger.Client.Test do
   test "can retrieve configuration", %{client: client} do
     config = [
       colors: %{debug: :cyan, enabled: true, error: :red, info: :normal, warn: :yellow},
-      format: ["\n", :time, " ", :metadata, "[", :level, "] ", :levelpad, :message, "\n"],
+      format: ["\n", :time, " ", :metadata, "[", :level, "] ", :message, "\n"],
       io: :stdio,
       level: :debug,
       metadata: [],

--- a/test/stress_test.exs
+++ b/test/stress_test.exs
@@ -3,6 +3,9 @@ defmodule StressTest do
 
   require Logger
 
+  # Elixir 1.4 changed the default pattern (removed $levelpad) so hardcode a default
+  # pattern here
+  @default_pattern "\n$time $metadata[$level] $message\n"
   @ring_size 11
 
   setup do
@@ -14,7 +17,7 @@ defmodule StressTest do
     Logger.flush()
 
     Logger.add_backend(RingLogger)
-    Logger.configure_backend(RingLogger, max_size: @ring_size)
+    Logger.configure_backend(RingLogger, max_size: @ring_size, format: @default_pattern)
 
     on_exit(fn ->
       RingLogger.TestIO.stop(pid)
@@ -60,7 +63,7 @@ defmodule StressTest do
           assert_receive {:io, messages}, 100
 
           for j <- 1..k do
-            assert messages =~ "[info]  #{k}: starter #{j}"
+            assert messages =~ "[info] #{k}: starter #{j}"
           end
         end
 


### PR DESCRIPTION
Elixir 1.4 removed support for `$levelpad` and dropped it from the
default formatter pattern. This updates the unit tests to force a format
pattern rather than relying on the default one.
