### PR TITLE
Correct entry type and extract entry specific logic

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -52,9 +52,7 @@ defmodule RingLogger do
           | {:application_levels, map()}
 
   @typedoc "A tuple holding a raw, unformatted log entry"
-  @type entry ::
-          {Logger.level(),
-           {module(), Logger.message(), Logger.Formatter.time(), Logger.metadata()}}
+  @type entry :: RingLogger.LogEntry.t()
 
   @typep custom_formatter :: {module, function}
 

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -53,7 +53,8 @@ defmodule RingLogger do
 
   @typedoc "A tuple holding a raw, unformatted log entry"
   @type entry ::
-          {module(), Logger.level(), Logger.message(), Logger.Formatter.time(), Logger.metadata()}
+          {Logger.level(),
+           {module(), Logger.message(), Logger.Formatter.time(), Logger.metadata()}}
 
   @typep custom_formatter :: {module, function}
 

--- a/lib/ring_logger/log_entry.ex
+++ b/lib/ring_logger/log_entry.ex
@@ -1,0 +1,18 @@
+defmodule RingLogger.LogEntry do
+  @moduledoc false
+
+  @typedoc "A tuple holding a raw, unformatted log entry"
+  @type t :: {Logger.level(), message_tuple}
+
+  @type message_tuple :: {module(), Logger.message(), Logger.Formatter.time(), Logger.metadata()}
+
+  @spec new(Logger.level(), message_tuple()) :: t()
+  def new(level, message_tuple) do
+    {level, message_tuple}
+  end
+
+  @spec put_index(t(), non_neg_integer()) :: t()
+  def put_index({level, {mod, msg, ts, md}}, index) do
+    {level, {mod, msg, ts, Keyword.put(md, :index, index)}}
+  end
+end


### PR DESCRIPTION
### Description

I notice that `entry` type spec is incorrect. Also it is a good opportunity to factor out log-entry-specific logic.

What do you think?

### Notes

The type spec of `entry` was:

```elixir
@type entry ::
          {
            module(), 
            Logger.level(), 
            Logger.message(), 
            Logger.Formatter.time(), 
            Logger.metadata()
          }
```

Here is actual data structure of log entries:
<img width="557" alt="CleanShot 2022-11-11 at 18 33 30@2x" src="https://user-images.githubusercontent.com/7563926/201444311-5c9c1331-dd76-4a47-a3dc-0666b78b04bc.png">
