### PR TITLE
Let count_next count logs per level instead of total

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -112,7 +112,14 @@ defmodule RingLogger do
   * Options from `attach/1`
   * `:pager` - a function for printing log messages to the console. Defaults to `IO.binwrite/2`.
   """
-  @spec count_next([client_option]) :: non_neg_integer() | {:error, term()}
+  @spec count_next([client_option]) ::
+          %{
+            info: non_neg_integer(),
+            debug: non_neg_integer(),
+            warn: non_neg_integer(),
+            error: non_neg_integer()
+          }
+          | {:error, term()}
   defdelegate count_next(opts \\ []), to: Autoclient
 
   @doc """

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -499,6 +499,22 @@ defmodule RingLoggerTest do
     end
   end
 
+  describe "count_next/1" do
+    test "returns per-level log counts for next set of log messages" do
+      assert RingLogger.count_next() == %{}
+      Logger.info('foo')
+      assert RingLogger.count_next() == %{info: 1}
+      Logger.debug('bar')
+      assert RingLogger.count_next() == %{info: 1, debug: 1}
+      Logger.warn('baz')
+      assert RingLogger.count_next() == %{info: 1, debug: 1, warn: 1}
+      Logger.error('uhh')
+      assert RingLogger.count_next() == %{info: 1, debug: 1, warn: 1, error: 1}
+      Logger.info('foo')
+      assert RingLogger.count_next() == %{info: 2, debug: 1, warn: 1, error: 1}
+    end
+  end
+
   defp capture_log(fun) do
     capture_io(:user, fn ->
       fun.()


### PR DESCRIPTION
Improvement on https://github.com/nerves-project/ring_logger/pull/99.

The output of the `count_next` function currently returns the total count of the unread, but the stats would be more useful if you have unread counts per log level.

Related PR: https://github.com/nerves-project/nerves_motd/issues/80

![CleanShot 2022-11-11 at 20 50 12@2x](https://user-images.githubusercontent.com/7563926/201450967-d1488f04-ed40-4fd8-9d0d-7aeb3fd2c609.png)
