### PR TITLE
Allow for multiple circular buffers based on log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,28 @@ use Mix.Config
 # default :console backend.
 config :logger, backends: [RingLogger]
 
-# Set the number of messages to hold in the circular buffer
+# Set the number of messages to hold in the default circular buffer
 config :logger, RingLogger, max_size: 1024
+
+# Configure multiple buffers based on log levels
+config :logger, RingLogger, buffers: %{
+  low_priority: %{
+    levels: [:warning, :notice, :info, :debug],
+    max_size: 1024
+  },
+  high_priority: %{
+    levels: [:emergency, :alert, :critical, :error],
+    max_size: 1024
+  }
+]
+
+# If levels are missing, the use the default logger
+config :logger, RingLogger, buffers: %{
+  errors: %{
+    levels: [:error, :warning],
+    max_size: 1024
+  }
+}
 
 # You can also configure `RingLogger.Client` options to be used
 # with every client by default

--- a/benchmarks/buffers.exs
+++ b/benchmarks/buffers.exs
@@ -1,0 +1,45 @@
+require Logger
+
+Logger.remove_backend(:console)
+Logger.add_backend(RingLogger)
+
+Benchee.run(
+  %{
+    "one buffer" => {
+      fn _input ->
+        Logger.debug("Low priority")
+        Logger.error("High priority")
+      end,
+      before_scenario: fn _input ->
+        Logger.configure_backend(RingLogger, max_size: 1024, buffers: %{})
+      end,
+      after_scenario: fn _input ->
+        IO.inspect Enum.count(RingLogger.get(0, 0))
+      end
+    },
+    "multiple buffers" => {
+      fn _input ->
+        Logger.debug("Low priority")
+        Logger.error("High priority")
+      end,
+      before_scenario: fn _input ->
+        Logger.configure_backend(RingLogger, max_size: 1024, buffers: %{
+          low_priority: %{
+            levels: [:warning, :notice, :info, :debug],
+            max_size: 1024
+          },
+          high_priority: %{
+            levels: [:emergency, :alert, :critical, :error],
+            max_size: 1024
+          }
+        })
+      end,
+      after_scenario: fn _input ->
+        IO.inspect Enum.count(RingLogger.get(0, 0))
+      end
+    }
+  },
+  after_scenario: fn _input ->
+    RingLogger.Server.clear()
+  end
+)

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -13,6 +13,26 @@ defmodule RingLogger do
 
   # Set the number of messages to hold in the circular buffer
   config :logger, RingLogger, max_size: 1024
+
+  # Configure multiple buffers based on log levels
+  config :logger, RingLogger, buffers: %{
+    low_priority: %{
+      levels: [:warning, :notice, :info, :debug],
+      max_size: 1024
+    },
+    high_priority: %{
+      levels: [:emergency, :alert, :critical, :error],
+      max_size: 1024
+    }
+  ]
+
+  # If levels are missing, the use the default logger
+  config :logger, RingLogger, buffers: %{
+    errors: %{
+      levels: [:error, :warning],
+      max_size: 1024
+    }
+  }
   ```
 
   Or add manually:

--- a/lib/ring_logger/buffer.ex
+++ b/lib/ring_logger/buffer.ex
@@ -1,0 +1,5 @@
+defmodule RingLogger.Buffer do
+  @moduledoc false
+
+  defstruct [:name, :levels, :max_size, :circular_buffer]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule RingLogger.MixProject do
   defp deps do
     [
       {:circular_buffer, "~> 0.4.0"},
+      {:benchee, "~> 1.1", only: :dev},
       {:ex_doc, "~> 0.18", only: :docs, runtime: false},
       {:dialyxir, "~> 1.2", only: :dev, runtime: false},
       {:credo, "~> 1.5", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "circular_buffer": {:hex, :circular_buffer, "0.4.1", "477f370fd8cfe1787b0a1bade6208bbd274b34f1610e41f1180ba756a7679839", [:mix], [], "hexpm", "633ef2e059dde0d7b89bbab13b1da9d04c6685e80e68fbdf41282d4fae746b72"},
   "credo": {:hex, :credo, "1.6.7", "323f5734350fd23a456f2688b9430e7d517afb313fbd38671b8a4449798a7854", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "41e110bfb007f7eda7f897c10bf019ceab9a0b269ce79f015d54b0dcf4fc7dd3"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.30", "0b938aa5b9bafd455056440cdaa2a79197ca5e693830b4a982beada840513c5f", [:mix], [], "hexpm", "3b5385c2d36b0473d0b206927b841343d25adb14f95f0110062506b300cd5a1b"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
@@ -12,4 +14,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
+  "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
 }

--- a/test/stress_test.exs
+++ b/test/stress_test.exs
@@ -17,7 +17,12 @@ defmodule StressTest do
     Logger.flush()
 
     Logger.add_backend(RingLogger)
-    Logger.configure_backend(RingLogger, max_size: @ring_size, format: @default_pattern)
+
+    Logger.configure_backend(RingLogger,
+      max_size: @ring_size,
+      format: @default_pattern,
+      buffers: []
+    )
 
     on_exit(fn ->
       RingLogger.TestIO.stop(pid)


### PR DESCRIPTION
If configured, allow for multiple buffers that are merged based on monotonic time. This allows for lower level logs to not be wiped out by verbose debug logging.