### PR TITLE
Store log entries as maps instead of tuples

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -75,10 +75,14 @@ defmodule RingLogger do
   @typedoc "Option list for client-side functions"
   @type client_options() :: [client_option()]
 
-  @typedoc "A tuple holding a raw, unformatted log entry"
-  @type entry() ::
-          {Logger.level(),
-           {module(), Logger.message(), Logger.Formatter.time(), Logger.metadata()}}
+  @typedoc "A map holding a raw, unformatted log entry"
+  @type entry() :: %{
+          map: Logger.level(),
+          module: module(),
+          message: Logger.message(),
+          timestamp: Logger.Formatter.time(),
+          metadata: Logger.metadata()
+        }
 
   @typep custom_formatter() :: {module, function}
 

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -291,14 +291,17 @@ defmodule RingLogger.Client do
     {:reply, rc, state}
   end
 
-  defp message_index({_level, {_, _msg, _ts, md}}), do: Keyword.get(md, :index)
+  defp message_index(%{metadata: metadata}), do: Keyword.get(metadata, :index)
 
-  defp format_message({level, {_, msg, ts, md}}, state) do
-    metadata = take_metadata(md, state.metadata)
+  defp format_message(
+         %{level: level, message: message, timestamp: timestamp, metadata: metadata},
+         state
+       ) do
+    metadata = take_metadata(metadata, state.metadata)
 
     state.format
-    |> apply_format(level, msg, ts, metadata)
-    |> color_event(level, state.colors, md)
+    |> apply_format(level, message, timestamp, metadata)
+    |> color_event(level, state.colors, metadata)
   end
 
   ## Helpers
@@ -453,11 +456,11 @@ defmodule RingLogger.Client do
     end
   end
 
-  defp get_module_from_msg({_, {_, _, _, meta}}) do
-    Keyword.get(meta, :module)
+  defp get_module_from_msg(%{metadata: metadata}) do
+    Keyword.get(metadata, :module)
   end
 
-  defp should_print?({level, _} = msg, %__MODULE__{module_levels: module_levels} = state) do
+  defp should_print?(%{level: level} = msg, %__MODULE__{module_levels: module_levels} = state) do
     module = get_module_from_msg(msg)
 
     with module_level when not is_nil(module_level) <- Map.get(module_levels, module),

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -249,7 +249,7 @@ defmodule RingLoggerTest do
     handshake_log(io, :debug, "Hello")
 
     buffer = RingLogger.get()
-    assert [{:debug, {Logger, "Hello", _, _}}] = buffer
+    assert [%{level: :debug, module: Logger, message: "Hello"}] = buffer
   end
 
   test "buffer does not exceed size", %{io: io} do
@@ -259,17 +259,25 @@ defmodule RingLoggerTest do
     handshake_log(io, :debug, "Foo")
 
     buffer = RingLogger.get()
-    assert [{:debug, {Logger, "Foo", _, _}}] = buffer
+    assert [%{level: :debug, module: Logger, message: "Foo"}] = buffer
 
     handshake_log(io, :debug, "Bar")
 
     buffer = RingLogger.get()
-    assert [{:debug, {Logger, "Foo", _, _}}, {:debug, {Logger, "Bar", _, _}}] = buffer
+
+    assert [
+             %{level: :debug, module: Logger, message: "Foo"},
+             %{level: :debug, module: Logger, message: "Bar"}
+           ] = buffer
 
     handshake_log(io, :debug, "Baz")
 
     buffer = RingLogger.get()
-    assert [{:debug, {Logger, "Bar", _, _}}, {:debug, {Logger, "Baz", _, _}}] = buffer
+
+    assert [
+             %{level: :debug, module: Logger, message: "Bar"},
+             %{level: :debug, module: Logger, message: "Baz"}
+           ] = buffer
   end
 
   test "buffer can be fetched by range", %{io: io} do
@@ -282,9 +290,13 @@ defmodule RingLoggerTest do
     |> handshake_log(:debug, "Baz")
 
     buffer = RingLogger.get(2)
-    assert [{:debug, {Logger, "Baz", _, _}}] = buffer
+    assert [%{level: :debug, module: Logger, message: "Baz"}] = buffer
     buffer = RingLogger.get(1)
-    assert [{:debug, {Logger, "Bar", _, _}}, {:debug, {Logger, "Baz", _, _}}] = buffer
+
+    assert [
+             %{level: :debug, module: Logger, message: "Bar"},
+             %{level: :debug, module: Logger, message: "Baz"}
+           ] = buffer
   end
 
   test "next supports passing a custom pager", %{io: io} do
@@ -360,7 +372,7 @@ defmodule RingLoggerTest do
     |> handshake_log(:debug, "Bar")
 
     buffer = RingLogger.get(0)
-    assert [{:debug, {Logger, "Bar", _, _}}] = buffer
+    assert [%{level: :debug, module: Logger, message: "Bar"}] = buffer
   end
 
   test "receive nothing when fetching buffer out of range" do
@@ -377,11 +389,21 @@ defmodule RingLoggerTest do
     |> handshake_log(:debug, "Baz")
 
     buffer = RingLogger.get(1, 1)
-    assert [{:debug, {Logger, "Bar", _, _}}] = buffer
+    assert [%{level: :debug, module: Logger, message: "Bar"}] = buffer
+
     buffer = RingLogger.get(1, 2)
-    assert [{:debug, {Logger, "Bar", _, _}}, {:debug, {Logger, "Baz", _, _}}] = buffer
+
+    assert [
+             %{level: :debug, module: Logger, message: "Bar"},
+             %{level: :debug, module: Logger, message: "Baz"}
+           ] = buffer
+
     buffer = RingLogger.get(1, 3)
-    assert [{:debug, {Logger, "Bar", _, _}}, {:debug, {Logger, "Baz", _, _}}] = buffer
+
+    assert [
+             %{level: :debug, module: Logger, message: "Bar"},
+             %{level: :debug, module: Logger, message: "Baz"}
+           ] = buffer
   end
 
   test "can format messages", %{io: io} do
@@ -546,7 +568,7 @@ defmodule RingLoggerTest do
       buffer = RingLogger.get(0, 0)
 
       # Should include the first 3 errors
-      [{:error, _}, {:error, _}, {:error, _} | _] = buffer
+      [%{level: :error}, %{level: :error}, %{level: :error} | _] = buffer
     end
 
     test "multiple buffers and indexing", %{io: io} do
@@ -574,7 +596,7 @@ defmodule RingLoggerTest do
 
       buffer = RingLogger.get(2, 3)
 
-      [{:debug, _}, {:error, _}, {:debug, _}] = buffer
+      [%{level: :debug}, %{level: :error}, %{level: :debug}] = buffer
     end
 
     test "`get(starting_index, 0)` returns everything after the starting index", %{io: io} do
@@ -602,7 +624,7 @@ defmodule RingLoggerTest do
 
       buffer = RingLogger.get(1, 0)
 
-      [{:debug, _}, {:error, _}, {:error, _}, {:debug, _}] = buffer
+      [%{level: :debug}, %{level: :error}, %{level: :error}, %{level: :debug}] = buffer
     end
 
     test "tailing multiple buffers", %{io: io} do


### PR DESCRIPTION
This lets us pick out the pieces we want instead of remembering the tuple position of everything. Memory is the same per benchee.