### PR TITLE
Periodically save the current buffers to a file, load on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ use Mix.Config
 # Add the RingLogger backend. This removes the default :console backend.
 config :logger, backends: [RingLogger]
 
+# Periodically save logs to a file, and load logs on GenServer start from this file
+config :logger, RingLogger, persist_path: "./myapp.log", persist_seconds: 300
+
 # Save messages to one circular buffer that holds 1024 entries.
 config :logger, RingLogger, max_size: 1024
 

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -10,6 +10,9 @@ defmodule RingLogger do
   # Add the RingLogger backend. This removes the default :console backend.
   config :logger, backends: [RingLogger]
 
+  # Periodically save logs to a file, and load logs on GenServer start from this file
+  config :logger, RingLogger, persist_path: "./myapp.log", persist_seconds: 300
+
   # Save messages to one circular buffer that holds 1024 entries.
   config :logger, RingLogger, max_size: 1024
 
@@ -56,7 +59,14 @@ defmodule RingLogger do
   alias RingLogger.Server
 
   @typedoc "Option values used by the ring logger"
-  @type server_option() :: {:max_size, pos_integer()}
+  @type server_option() ::
+          {:max_size, pos_integer()}
+          | {:buffers, %{term() => buffer()}}
+          | {:persist_path, String.t()}
+          | {:persist_seconds, pos_integer()}
+
+  @typedoc "Options to define a separate buffer based on log levels"
+  @type buffer() :: %{levels: [Logger.level()], max_size: pos_integer()}
 
   @typedoc "Callback function for printing/paging tail, grep, and next output"
   @type pager_fun() :: (IO.device(), IO.chardata() -> :ok | {:error, term()})

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -112,6 +112,7 @@ defmodule RingLogger.Client do
     {io, to_print} = GenServer.call(client_pid, :next)
 
     pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+
     pager.(io, to_print)
   end
 

--- a/lib/ring_logger/persistence.ex
+++ b/lib/ring_logger/persistence.ex
@@ -1,0 +1,24 @@
+defmodule RingLogger.Persistence do
+  @moduledoc false
+
+  @spec load(String.t()) :: [RingLogger.entry()] | {:error, atom()}
+  def load(path) do
+    path
+    |> File.read!()
+    |> :erlang.binary_to_term()
+  rescue
+    error in File.Error ->
+      {:error, error.reason}
+
+    ArgumentError ->
+      {:error, :corrupted}
+  end
+
+  @spec save(String.t(), [RingLogger.entry()]) :: :ok | {:error, atom()}
+  def save(path, logs) do
+    File.write!(path, :erlang.term_to_binary(logs))
+  rescue
+    error in File.Error ->
+      {:error, error.reason}
+  end
+end

--- a/test/ring_logger/persistence_test.exs
+++ b/test/ring_logger/persistence_test.exs
@@ -1,0 +1,73 @@
+defmodule RingLogger.PersistenceTest do
+  use ExUnit.Case, async: false
+
+  alias RingLogger.Persistence
+
+  test "saving logs" do
+    File.rm("test/persistence.log")
+
+    logs = [
+      %{
+        level: :debug,
+        module: Logger,
+        message: "Foo",
+        timestamp: {{2023, 2, 8}, {13, 58, 31, 343}},
+        metadata: []
+      },
+      %{
+        level: :debug,
+        module: Logger,
+        message: "Bar",
+        timestamp: {{2023, 2, 8}, {13, 58, 31, 343}},
+        metadata: []
+      }
+    ]
+
+    :ok = Persistence.save("test/persistence.log", logs)
+
+    assert File.exists?("test/persistence.log")
+
+    File.rm("test/persistence.log")
+  end
+
+  test "loading logs" do
+    File.rm("test/persistence.log")
+
+    logs = [
+      %{
+        level: :debug,
+        module: Logger,
+        message: "Foo",
+        timestamp: {{2023, 2, 8}, {13, 58, 31, 343}},
+        metadata: []
+      },
+      %{
+        level: :debug,
+        module: Logger,
+        message: "Bar",
+        timestamp: {{2023, 2, 8}, {13, 58, 31, 343}},
+        metadata: []
+      }
+    ]
+
+    :ok = Persistence.save("test/persistence.log", logs)
+
+    loaded_logs = Persistence.load("test/persistence.log")
+
+    assert logs == loaded_logs
+
+    File.rm("test/persistence.log")
+  end
+
+  test "file was corrupted" do
+    File.write!("test/persistence.log", "bad file")
+
+    assert {:error, :corrupted} = Persistence.load("test/persistence.log")
+
+    File.rm("test/persistence.log")
+  end
+
+  test "file doesn't exist" do
+    assert {:error, :enoent} = Persistence.load("test/persistence.log")
+  end
+end


### PR DESCRIPTION
Persist the current circular buffers every `:persist_seconds`. When the backend starts, try to load the persisted logs and reinsert into the configured buffers.