### PR TITLE
Fix `entry` typespec typo

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -87,7 +87,7 @@ defmodule RingLogger do
 
   @typedoc "A map holding a raw, unformatted log entry"
   @type entry() :: %{
-          map: Logger.level(),
+          level: Logger.level(),
           module: module(),
           message: Logger.message(),
           timestamp: Logger.Formatter.time(),


### PR DESCRIPTION
Noticed what seems to be a tiny typo while upgrading to 0.10.