### PR TITLE
fix(client): make has_metadata? private

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -535,7 +535,7 @@ defmodule RingLogger.Client do
   end
 
   @spec has_metadata?(RingLogger.entry(), atom(), String.t() | Regex.t()) :: boolean()
-  def has_metadata?(%{metadata: metadata}, key, match_value) do
+  defp has_metadata?(%{metadata: metadata}, key, match_value) do
     case metadata[key] do
       nil -> false
       val when is_binary(val) -> val =~ match_value


### PR DESCRIPTION
This is a public function by mistake, let's make it private.