### PR TITLE
Fix loading history when multiple buffers in config

### DIFF
--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -137,6 +137,8 @@ defmodule RingLogger.Server do
   end
 
   def handle_call({:configure, opts}, _from, state) do
+    logs = merge_buffers(state)
+
     state =
       case Keyword.get(opts, :max_size) do
         nil ->
@@ -154,6 +156,9 @@ defmodule RingLogger.Server do
         buffers ->
           %__MODULE__{state | buffers: reset_buffers(buffers)}
       end
+
+    # Reinsert old buffers to let new max size filter out
+    state = Enum.reduce(logs, state, &insert_log(&2, &1))
 
     {:reply, :ok, state}
   end


### PR DESCRIPTION
When starting the RingLogger backend, the `RingLogger.Server` loads any history from a persistence file during init, then configures the Server after successfully starting up. However, the configure action was destructive and would reset all the buffers which were just loaded if you happened to have buffer configuration.

This fixes that to reload any existing buffer back into the newly configured ones so that history would not be lost when adjusting minor configuration