### PR TITLE
Persist logs on terminate if appropriate.

### DIFF
--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -208,7 +208,7 @@ defmodule RingLogger.Server do
     {:noreply, detach_client(pid, state)}
   end
 
-  def handle_info(:tick, state = %__MODULE__{perist_path: path}) when is_binary(path) do
+  def handle_info(:tick, state = %__MODULE__{persist_path: path}) when is_binary(path) do
     Process.send_after(self(), :tick, state.persist_seconds * 1000)
 
     case Persistence.save(state.persist_path, merge_buffers(state)) do

--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -208,7 +208,7 @@ defmodule RingLogger.Server do
     {:noreply, detach_client(pid, state)}
   end
 
-  def handle_info(:tick, state) do
+  def handle_info(:tick, state = %__MODULE__{perist_path: path}) when is_binary(path) do
     Process.send_after(self(), :tick, state.persist_seconds * 1000)
 
     case Persistence.save(state.persist_path, merge_buffers(state)) do
@@ -222,10 +222,24 @@ defmodule RingLogger.Server do
     end
   end
 
+  def handle_info(:tick, state = %__MODULE__{persist_path: path}) do
+    Logger.warning("RingLogger attempt to persisting log when the path (#{path}) is invalid")
+  end
+
   @impl GenServer
-  def terminate(_reason, state) do
-    Enum.each(state.clients, fn {client_pid, _ref} -> Client.stop(client_pid) end)
+  def terminate(_reason, state = %__MODULE__{persist_path: path}) when is_binary(path) do
+    Persistence.save(state.persist_path, merge_buffers(state))
+    close_all_clients(state)
     :ok
+  end
+
+  def terminate(_reason, state) do
+    close_all_clients(state)
+    :ok
+  end
+
+  defp close_all_clients(state) do
+    Enum.each(state.clients, fn {client_pid, _ref} -> Client.stop(client_pid) end)
   end
 
   defp adjust_left({offset, n}, i) when i > offset do


### PR DESCRIPTION
If the logs are being persisted periodically, then it would also be useful if they are persisted as part of a terminate event to avoid losing logs to a `Nerves.Runtime.reboot/0`.