### PR TITLE
Ringlogger Enhancements: Multiple Application Filter Support, Argument Support to RingLogger Launch Command, Filter Support For Date Navigation

### DIFF
--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -196,8 +196,14 @@ defmodule RingLogger do
   @doc """
   Starts the Ring Logger Viewer TUI app on the current prompt
   """
+  @spec viewer(String.t()) :: :ok
+  def viewer(cmd_string), do: RingLogger.Viewer.view(cmd_string)
+
+  @doc """
+  Starts the Ring Logger Viewer TUI app on the current prompt and passes empty string
+  """
   @spec viewer() :: :ok
-  def viewer(), do: RingLogger.Viewer.view()
+  def viewer(), do: RingLogger.Viewer.view("")
 
   @doc """
   Reset the index into the log for `next/1` to the oldest entry.

--- a/lib/ring_logger.ex
+++ b/lib/ring_logger.ex
@@ -55,6 +55,7 @@ defmodule RingLogger do
   """
   @behaviour :gen_event
 
+  alias RingLogger.Viewer
   alias RingLogger.Autoclient
   alias RingLogger.Server
 
@@ -194,16 +195,16 @@ defmodule RingLogger do
   def tail(n, opts), do: Autoclient.tail(n, opts)
 
   @doc """
-  Starts the Ring Logger Viewer TUI app on the current prompt
+  Starts the Ring Logger Viewer TUI app on the current prompt with intial arguments
   """
   @spec viewer(String.t()) :: :ok
-  def viewer(cmd_string), do: RingLogger.Viewer.view(cmd_string)
+  defdelegate viewer(cmd_string), to: Viewer, as: :view
 
   @doc """
-  Starts the Ring Logger Viewer TUI app on the current prompt and passes empty string
+  Starts the Ring Logger Viewer TUI app on the current prompt
   """
   @spec viewer() :: :ok
-  def viewer(), do: RingLogger.Viewer.view("")
+  defdelegate viewer(), to: Viewer, as: :view
 
   @doc """
   Reset the index into the log for `next/1` to the oldest entry.

--- a/lib/ring_logger/viewer.ex
+++ b/lib/ring_logger/viewer.ex
@@ -40,6 +40,8 @@ defmodule RingLogger.Viewer do
 
   @level_strings ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
 
+  @microsecond_factor 1_000_000
+
   @spec view(String.t()) :: :ok
   def view(cmd_string \\ "") do
     screen_dims = get_screen_dims()
@@ -55,9 +57,11 @@ defmodule RingLogger.Viewer do
     parse_launch_cmd(cmd_string, @init_state) |> get_log_snapshot() |> loop()
   end
 
+  @doc """
+  updates state by applying multiple filters to initial state or return initial state
+  """
   def parse_launch_cmd("", state), do: state
 
-  # parse_launch_cmd/2 returns updated state by applying multiple filters to initial state
   def parse_launch_cmd(cmd_string, state) do
     cmd_list = String.split(cmd_string, ";")
 
@@ -160,7 +164,7 @@ defmodule RingLogger.Viewer do
       if state.applications_filter[:start_time] == nil do
         "[#{state.current_page}/#{state.last_page}] "
       else
-        {:ok, dt} = DateTime.from_unix(div(state.applications_filter[:start_time], 1_000_000))
+        {:ok, dt} = DateTime.from_unix(div(state.applications_filter[:start_time], @microsecond_factor))
         "[#{state.current_page}(#{dt})/#{state.last_page}] "
       end
 
@@ -439,8 +443,8 @@ defmodule RingLogger.Viewer do
         {:ok, dt, _offset} = DateTime.from_iso8601(coupled)
 
         # we recieve time in ringlogger micro secs so to imporve precision we have multiplied secs with micro secs order
-        dt_start_micro_secs = DateTime.to_unix(dt) * 1_000_000
-        dt_end_micro_secs = DateTime.to_unix(dt) * 1_000_000 + 1_000_000
+        dt_start_micro_secs = DateTime.to_unix(dt) * @microsecond_factor
+        dt_end_micro_secs = DateTime.to_unix(dt) * @microsecond_factor + @microsecond_factor
 
         %{
           state

--- a/lib/ring_logger/viewer.ex
+++ b/lib/ring_logger/viewer.ex
@@ -59,6 +59,7 @@ defmodule RingLogger.Viewer do
     end
   end
 
+  # parse_launch_cmd/2 returns updated state by applying multiple filters to initial state
   defp parse_launch_cmd(cmd_string, state) do
     cmd_list = String.split(cmd_string, ";")
 
@@ -71,6 +72,7 @@ defmodule RingLogger.Viewer do
     %{state | current_page: 0}
   end
 
+  # apply_command_parser/3 returns state by applying single filter
   defp apply_command_parser(cmd_char, cmd, state) do
     case {cmd_char, cmd, state} do
       {"l", cmd, state} -> set_log_level(cmd, state)

--- a/lib/ring_logger/viewer.ex
+++ b/lib/ring_logger/viewer.ex
@@ -52,15 +52,13 @@ defmodule RingLogger.Viewer do
       raise "Sorry, your terminal needs to be at least #{@min_height} rows high to use this tool!"
     end
 
-    if String.equivalent?(cmd_string, "") do
-      @init_state |> get_log_snapshot() |> loop()
-    else
-      parse_launch_cmd(cmd_string, @init_state) |> get_log_snapshot() |> loop()
-    end
+    parse_launch_cmd(cmd_string, @init_state) |> get_log_snapshot() |> loop()
   end
 
+  def parse_launch_cmd("", state), do: state
+
   # parse_launch_cmd/2 returns updated state by applying multiple filters to initial state
-  defp parse_launch_cmd(cmd_string, state) do
+  def parse_launch_cmd(cmd_string, state) do
     cmd_list = String.split(cmd_string, ";")
 
     state =
@@ -517,9 +515,9 @@ defmodule RingLogger.Viewer do
       "\t(g)rep [regex/string] - regex/string search expression, leaving argument blank clears filter.\n",
       "\t(l)evel [log_level] - filter to specified level (or higher), leaving level blank clears the filter.\n",
       "\t(a)pp [atom] - adds/remove an atom from the 'application' metadata filter, leaving argument blank clears filter.\n",
-      "\t(a)pp [atom] [atom] [atom] - adds/remove an multiple atoms from the 'application' metadata filter, leaving argument blank clears filter.\n",
-      "\t(;)concat commands [example usage] - a telit_modem; d 2024-12-25 10:20:01 \n",
+      "\t(a)pp [atom] [atom] [atom] - adds/remove an multiple atoms from the 'application' metadata filter.Same as multiple uses of a [atom]\n",
       "\t(d)ate (goto date)command - d 2024-12-25 10:20:01 \n",
+      "\t(;)concat commands [example usage] - a telit_modem; d 2024-12-25 10:20:01 \n",
       "\t0..n - input any table index number to fully inspect a log line, and view its metadata.\n",
       "\t(e)xit or (q)uit - closes the log viewer.\n",
       "\t(h)elp / ? - show this screen.\n",

--- a/lib/ring_logger/viewer.ex
+++ b/lib/ring_logger/viewer.ex
@@ -40,8 +40,8 @@ defmodule RingLogger.Viewer do
 
   @level_strings ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
 
-  @spec view() :: :ok
-  def view() do
+  @spec view(String.t()) :: :ok
+  def view(cmd_string \\ "") do
     screen_dims = get_screen_dims()
 
     if screen_dims.w <= @min_width do
@@ -52,9 +52,35 @@ defmodule RingLogger.Viewer do
       raise "Sorry, your terminal needs to be at least #{@min_height} rows high to use this tool!"
     end
 
-    IO.puts("Starting RingLogger Viewer...")
+    if String.equivalent?(cmd_string, "") do
+      @init_state |> get_log_snapshot() |> loop()
+    else
+      parse_launch_cmd(cmd_string, @init_state) |> get_log_snapshot() |> loop()
+    end
+  end
 
-    @init_state |> get_log_snapshot() |> loop()
+  defp parse_launch_cmd(cmd_string, state) do
+    cmd_list = String.split(cmd_string, ";")
+
+    state =
+      Enum.reduce(cmd_list, state, fn cmd, state ->
+        cmd_char = String.trim_leading(cmd, " ") |> String.at(0) |> String.downcase()
+        apply_command_parser(cmd_char, cmd, state)
+      end)
+
+    %{state | current_page: 0}
+  end
+
+  defp apply_command_parser(cmd_char, cmd, state) do
+    case {cmd_char, cmd, state} do
+      {"l", cmd, state} -> set_log_level(cmd, state)
+      {"a", cmd, state} -> add_remove_app(cmd, state)
+      {"d", cmd, state} -> add_time_log(cmd, state)
+      {"r", _cmd, _state} -> %{@init_state | current_page: 0}
+      {"g", cmd, state} -> add_remove_grep(cmd, state)
+      {"q", _cmd, state} -> %{state | running: false}
+      _ -> state
+    end
   end
 
   #### Drawing and IO Functions
@@ -130,7 +156,13 @@ defmodule RingLogger.Viewer do
   end
 
   defp compute_prompt(state) do
-    prefix = "[#{state.current_page}/#{state.last_page}] "
+    prefix =
+      if state.applications_filter[:start_time] == nil do
+        "[#{state.current_page}/#{state.last_page}] "
+      else
+        {:ok, dt} = DateTime.from_unix(div(state.applications_filter[:start_time], 1_000_000))
+        "[#{state.current_page}(#{dt})/#{state.last_page}] "
+      end
 
     level_suffix =
       if state.lowest_log_level != nil do
@@ -138,7 +170,7 @@ defmodule RingLogger.Viewer do
       end
 
     app_suffix =
-      if state.applications_filter != [] do
+      if state.applications_filter != [] and state.applications_filter[:start_time] == nil do
         inspect(state.applications_filter)
       end
 
@@ -198,7 +230,6 @@ defmodule RingLogger.Viewer do
   end
 
   #### Log Filtering / Pagination Functions
-
   defp get_log_snapshot(state) do
     IO.puts("Fetching and Filtering Logs...")
 
@@ -209,7 +240,6 @@ defmodule RingLogger.Viewer do
         raw = RingLogger.get()
 
         boot_index = find_starting_index(raw)
-
         # Index needs to be negative because we searched from the end of the list
         {_, split_segment} = Enum.split(raw, -boot_index)
         split_segment
@@ -241,15 +271,19 @@ defmodule RingLogger.Viewer do
 
   defp apply_log_filters(entries, state) do
     Enum.filter(entries, fn entry ->
-      maybe_apply_app_filter?(state, entry) and maybe_apply_level_filter?(state, entry) and
+      maybe_apply_app_or_time_filter?(state, entry) and maybe_apply_level_filter?(state, entry) and
         maybe_apply_grep_filter?(state, entry)
     end)
   end
 
-  defp maybe_apply_app_filter?(%{applications_filter: []}, _entry), do: true
+  defp maybe_apply_app_or_time_filter?(%{applications_filter: []}, _entry), do: true
 
-  defp maybe_apply_app_filter?(%{applications_filter: app_list}, entry),
-    do: entry.metadata[:application] in app_list
+  defp maybe_apply_app_or_time_filter?(%{applications_filter: app_list} = state, entry) do
+    case app_list[:start_time] do
+      nil -> entry.metadata[:application] in app_list
+      _ -> check_date_range(state, entry)
+    end
+  end
 
   defp maybe_apply_level_filter?(%{lowest_log_level: nil}, _entry), do: true
 
@@ -260,6 +294,11 @@ defmodule RingLogger.Viewer do
 
   defp maybe_apply_grep_filter?(%{grep_filter: expression}, entry),
     do: Regex.match?(expression, entry.message)
+
+  defp check_date_range(state, entry) do
+    entry.metadata[:time] >= state.applications_filter[:start_time] &&
+      entry.metadata[:time] <= state.applications_filter[:end_time]
+  end
 
   #### Command Handler Functions
 
@@ -276,11 +315,19 @@ defmodule RingLogger.Viewer do
         inspect_entry(index, state, current_logs)
         state
       else
-        first_char = String.at(cmd_string, 0) |> String.downcase()
-        command(first_char, cmd_string, state)
+        handle_commands(cmd_string, state, String.contains?(cmd_string, ";"))
       end
 
     %{new_state | last_cmd_string: cmd_string}
+  end
+
+  defp handle_commands(cmd_string, state, true) do
+    parse_launch_cmd(cmd_string, state) |> get_log_snapshot()
+  end
+
+  defp handle_commands(cmd_string, state, false) do
+    cmd = String.at(cmd_string, 0) |> String.downcase()
+    command(cmd, cmd_string, state)
   end
 
   defp command(cmd_exit, _cmd_string, state) when cmd_exit in ["e", "q"] do
@@ -317,6 +364,10 @@ defmodule RingLogger.Viewer do
 
   defp command("a", cmd_string, state) do
     add_remove_app(cmd_string, state) |> get_log_snapshot()
+  end
+
+  defp command("d", cmd_string, state) do
+    add_time_log(cmd_string, state) |> get_log_snapshot()
   end
 
   defp command("g", cmd_string, state) do
@@ -380,6 +431,30 @@ defmodule RingLogger.Viewer do
     end
   end
 
+  defp add_time_log(cmd_string, state) do
+    case String.split(cmd_string) do
+      [_cmd, date, time] ->
+        coupled = date <> "T" <> time <> "Z"
+
+        {:ok, dt, _offset} = DateTime.from_iso8601(coupled)
+
+        # we recieve time in ringlogger micro secs so to imporve precision we have multiplied secs with micro secs order
+        dt_start_micro_secs = DateTime.to_unix(dt) * 1_000_000
+        dt_end_micro_secs = DateTime.to_unix(dt) * 1_000_000 + 1_000_000
+
+        %{
+          state
+          | applications_filter: [start_time: dt_start_micro_secs, end_time: dt_end_micro_secs],
+            current_page: 0
+        }
+
+      _ ->
+        state
+    end
+  rescue
+    _ -> state
+  end
+
   defp add_remove_app(cmd_string, state) do
     case String.split(cmd_string) do
       [_cmd] ->
@@ -397,6 +472,12 @@ defmodule RingLogger.Viewer do
         else
           %{state | applications_filter: [app_atom | state.applications_filter], current_page: 0}
         end
+
+      # accept the series of applications if entered by user and convert them to atoms list
+      [_cmd | app_strings] ->
+        app_atom = Enum.map(app_strings, &String.to_existing_atom/1)
+
+        %{state | applications_filter: app_atom, current_page: 0}
 
       _ ->
         state
@@ -434,6 +515,9 @@ defmodule RingLogger.Viewer do
       "\t(g)rep [regex/string] - regex/string search expression, leaving argument blank clears filter.\n",
       "\t(l)evel [log_level] - filter to specified level (or higher), leaving level blank clears the filter.\n",
       "\t(a)pp [atom] - adds/remove an atom from the 'application' metadata filter, leaving argument blank clears filter.\n",
+      "\t(a)pp [atom] [atom] [atom] - adds/remove an multiple atoms from the 'application' metadata filter, leaving argument blank clears filter.\n",
+      "\t(;)concat commands [example usage] - a telit_modem; d 2024-12-25 10:20:01 \n",
+      "\t(d)ate (goto date)command - d 2024-12-25 10:20:01 \n",
       "\t0..n - input any table index number to fully inspect a log line, and view its metadata.\n",
       "\t(e)xit or (q)uit - closes the log viewer.\n",
       "\t(h)elp / ? - show this screen.\n",

--- a/test/ring_logger/viewer_test.exs
+++ b/test/ring_logger/viewer_test.exs
@@ -51,4 +51,70 @@ defmodule RingLogger.ViewerTest do
     # observe in logs you wont find (debug) anywhere writtem at the bottom left corner
     assert :ok = RingLogger.Viewer.view("r l debug; q")
   end
+
+  test "a command with single application", %{state: _state} do
+    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.debug("---------enter q to exit out of given test-----", application: :User)
+
+    assert :ok = RingLogger.Viewer.view("a telit_modem; q")
+  end
+
+  test "a command with multiple applications", %{state: _state} do
+    Logger.debug("blofeld debug level sample msg",
+      application: :blofeld_firmware,
+      time: 1_735_140_308_331_070
+    )
+
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.info("---------enter q to exit out of given test-----", application: :User)
+
+    assert :ok = RingLogger.Viewer.view("a nil blofeld_firmware peridiod; q")
+  end
+
+  test "goto date command with Invalid arguments using Ringlogger.view/1 command", %{
+    state: _state
+  } do
+    Logger.debug("blofeld debug level sample msg",
+      application: :blofeld_firmware,
+      time: 1_735_160_108_000_011
+    )
+
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+
+    Logger.info("---------enter q to exit out of given test-----",
+      application: :User,
+      time: 1_735_160_108_000_011
+    )
+
+    assert :ok = RingLogger.Viewer.view("d 2024-1; q")
+  end
+
+  test "goto date command with valid arguments using Ringlogger.view/1 command", %{state: _state} do
+    Logger.debug("blofeld debug level sample msg",
+      application: :blofeld_firmware,
+      time: 1_735_160_108_000_011
+    )
+
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+
+    Logger.info("---------enter q to exit out of given test-----",
+      application: :User,
+      time: 1_735_160_108_000_011
+    )
+
+    assert :ok = RingLogger.Viewer.view("d 2024-12-25 20:55:08; q")
+  end
 end

--- a/test/ring_logger/viewer_test.exs
+++ b/test/ring_logger/viewer_test.exs
@@ -30,66 +30,67 @@ defmodule RingLogger.ViewerTest do
   end
 
   test "Ringlogger.view/1 with multiple commands ; separated", %{state: _state} do
-    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.debug("Ringlogger debug level sample msg", application: :Ringlogger_firmware)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
     Logger.debug("---------enter q to exit out of given test-----", application: :User)
 
     assert :ok = RingLogger.Viewer.view("a telit_modem;l debug; q")
   end
 
   test "Ringlogger.view/1 with invalid command format", %{state: _state} do
-    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.debug("Ringlogger debug level sample msg", application: :Ringlogger_firmware)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
     Logger.info("---------enter q to exit out of given test-----", application: :User)
 
     # observe in logs you wont find (debug) anywhere writtem at the bottom left corner
     assert :ok = RingLogger.Viewer.view("r l debug; q")
   end
 
+
   test "a command with single application", %{state: _state} do
-    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.debug("Ringlogger debug level sample msg", application: :Ringlogger_firmware)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
     Logger.debug("---------enter q to exit out of given test-----", application: :User)
 
     assert :ok = RingLogger.Viewer.view("a telit_modem; q")
   end
 
   test "a command with multiple applications", %{state: _state} do
-    Logger.debug("blofeld debug level sample msg",
-      application: :blofeld_firmware,
+    Logger.debug("Ringlogger debug level sample msg",
+      application: :Ringlogger_firmware,
       time: 1_735_140_308_331_070
     )
 
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
     Logger.info("---------enter q to exit out of given test-----", application: :User)
 
-    assert :ok = RingLogger.Viewer.view("a nil blofeld_firmware peridiod; q")
+    assert :ok = RingLogger.Viewer.view("a nil Ringlogger_firmware peridiod; q")
   end
 
-  test "goto date command with Invalid arguments using Ringlogger.view/1 command", %{
+ test "goto date command with Invalid arguments using Ringlogger.view/1 command", %{
     state: _state
   } do
-    Logger.debug("blofeld debug level sample msg",
-      application: :blofeld_firmware,
+    Logger.debug("Ringlogger debug level sample msg",
+      application: :Ringlogger_firmware,
       time: 1_735_160_108_000_011
     )
 
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
 
     Logger.info("---------enter q to exit out of given test-----",
       application: :User,
@@ -100,15 +101,15 @@ defmodule RingLogger.ViewerTest do
   end
 
   test "goto date command with valid arguments using Ringlogger.view/1 command", %{state: _state} do
-    Logger.debug("blofeld debug level sample msg",
-      application: :blofeld_firmware,
+    Logger.debug("Ringlogger debug level sample msg",
+      application: :Ringlogger_firmware,
       time: 1_735_160_108_000_011
     )
 
-    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
-    Logger.info("blofeld info level sample msg", application: :peridiod)
-    Logger.critical("blofeld critical level sample msg", application: nil)
-    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.warning("Ringlogger warn level sample msg", application: :telit_modem)
+    Logger.info("Ringlogger info level sample msg", application: :peridiod)
+    Logger.critical("Ringlogger critical level sample msg", application: nil)
+    Logger.emergency("Ringlogger emergency level sample msg", application: :Vintage_Net)
 
     Logger.info("---------enter q to exit out of given test-----",
       application: :User,

--- a/test/ring_logger/viewer_test.exs
+++ b/test/ring_logger/viewer_test.exs
@@ -1,0 +1,54 @@
+defmodule RingLogger.ViewerTest do
+  use ExUnit.Case, async: false
+
+  require Logger
+
+  @default_pattern "\n$time $metadata[$level] $message\n"
+
+  setup do
+    Logger.remove_backend(:console)
+
+    Logger.flush()
+
+    Logger.add_backend(RingLogger)
+
+    Logger.configure_backend(RingLogger,
+      max_size: 10,
+      format: @default_pattern,
+      metadata: [:request_id, :file, :line, :module, :function, :time],
+      buffers: [],
+      persist_path: "/temp/file.log",
+      persist_seconds: 1_000
+    )
+
+    on_exit(fn ->
+      File.rm("/temp/file.log")
+      Logger.remove_backend(RingLogger)
+    end)
+
+    {:ok, %{state: nil}}
+  end
+
+  test "Ringlogger.view/1 with multiple commands ; separated", %{state: _state} do
+    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.debug("---------enter q to exit out of given test-----", application: :User)
+
+    assert :ok = RingLogger.Viewer.view("a telit_modem;l debug; q")
+  end
+
+  test "Ringlogger.view/1 with invalid command format", %{state: _state} do
+    Logger.debug("blofeld debug level sample msg", application: :blofeld_firmware)
+    Logger.warning("blofeld warn level sample msg", application: :telit_modem)
+    Logger.info("blofeld info level sample msg", application: :peridiod)
+    Logger.critical("blofeld critical level sample msg", application: nil)
+    Logger.emergency("blofeld emergency level sample msg", application: :Vintage_Net)
+    Logger.info("---------enter q to exit out of given test-----", application: :User)
+
+    # observe in logs you wont find (debug) anywhere writtem at the bottom left corner
+    assert :ok = RingLogger.Viewer.view("r l debug; q")
+  end
+end


### PR DESCRIPTION
This PR introduces several enhancements to the Ringlogger viewer command systems, improving its flexibility and functionality:

1.Enhancement to existing application list command:
Now application command can accept a list of applications, which allows more dynamic interaction with multiple applications at once.

2.Optional Initial Command String for Launch Command:
Launch command is modified to accept string as an argument, enabling users to pass additional parameters as command string directly during launch.
Additional command string can be as follows:
	1. Ringlogger.viewer("l debug")
	2. Ringlogger.viewer("a app_one app_two app_three")
	3. Ringlogger.viewer("d 2025-12-11 10:20:11")
	4. Ringlogger.viewer("r")
	5. Ringlogger.viewer("g grab_some_data")
	6. Ringlogger.viewer("q")

3.Addition of New Command for Date Entry Navigation:
A new command has been added to facilitate easy navigation to the date entry section. This improves the overall user experience when working with time-sensitive data.


These changes aim to provide greater control and customisation for users interacting with the Ringlogger command system, enhancing both usability and diagnostic capabilities.


Testing:
1. Unit Test cases are updated for these enhancements
2. Conducted manual testing to validate the functionality of the newly introduced commands, ensuring they work as expected in various scenarios.
3. Verified that the launch command correctly accepts and processes optional arguments while maintaining full backward compatibility.
4. Confirmed that the new date entry navigation command accurately redirects to the date entry section, enhancing usability for time-sensitive operations

Demo:
**command:** > a nil $kmsg telit_modem
![Screenshot from 2025-01-28 18-37-57](https://github.com/user-attachments/assets/82179438-c96f-42e8-a566-23d2c09bec5d)
**Response:**
![Screenshot from 2025-01-28 18-37-36](https://github.com/user-attachments/assets/1bae17f2-e7b4-4274-9fe1-3aaa3b968425)

**command:** Ringlogger.viewer("l info; a telit_modem vintage_net")
<img width="606" alt="FAQM-1582-launch-command-with-args 2" src="https://github.com/user-attachments/assets/d1cfef78-f4fe-4826-9378-ee03212b160e" />
**Response:**
![launch-command-test-preview](https://github.com/user-attachments/assets/d9b73533-911a-4f62-98d3-4d5a42d57db5)

**command:** > d 2025-01-06 05:54:10
![goto-date-command](https://github.com/user-attachments/assets/c1b8dcc6-b9b7-40ec-b850-9e8dfeb842c5)
**Response:**
![goto-date-test-preview](https://github.com/user-attachments/assets/b700126e-50fc-421f-be12-8a0450136076)





