### PR TITLE
Fix hang on OTP 28 due to non-Unicode output

### DIFF
--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -96,7 +96,7 @@ defmodule RingLogger.Client do
   def tail(client_pid, n, opts \\ []) do
     {io, to_print} = GenServer.call(client_pid, {:tail, n})
 
-    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager = Keyword.get(opts, :pager, &IO.write/2)
     pager.(io, to_print)
   end
 
@@ -111,7 +111,7 @@ defmodule RingLogger.Client do
   def next(client_pid, opts \\ []) do
     {io, to_print} = GenServer.call(client_pid, :next)
 
-    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager = Keyword.get(opts, :pager, &IO.write/2)
 
     pager.(io, to_print)
   end
@@ -167,7 +167,7 @@ defmodule RingLogger.Client do
   def grep_metadata(client_pid, key, %Regex{} = regex, opts) do
     {io, to_print} = GenServer.call(client_pid, {:grep_metadata, key, regex, opts})
 
-    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager = Keyword.get(opts, :pager, &IO.write/2)
     pager.(io, to_print)
   end
 
@@ -193,7 +193,7 @@ defmodule RingLogger.Client do
   def grep(client_pid, %Regex{} = regex, opts) do
     {io, to_print} = GenServer.call(client_pid, {:grep, regex, opts})
 
-    pager = Keyword.get(opts, :pager, &IO.binwrite/2)
+    pager = Keyword.get(opts, :pager, &IO.write/2)
     pager.(io, to_print)
   end
 
@@ -484,7 +484,7 @@ defmodule RingLogger.Client do
   defp maybe_print(msg, state) do
     if should_print?(msg, state) do
       item = format_message(msg, state)
-      IO.binwrite(state.io, item)
+      IO.write(state.io, item)
     end
   end
 

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -555,22 +555,28 @@ defmodule RingLoggerTest do
     assert message =~ "[info] Cześć!"
   end
 
-  test "logging corrupt data", %{io: io} do
-    # This is non-Unicode and shouldn't crash RingLogger. There are slightly
-    # different paths that are taken for iodata vs binary data, so make sure
-    # they behave identically.
-    message_string = <<227, 97, 195, 253, 123, 50, 91, 116, 114, 227, 110>>
-    message = [message_string]
+  if Version.match?(System.version(), ">= 1.16.0") do
+    # Restrict to Elixir 1.16 and later due to support for replacing invalid characters
+    test "logging corrupt data", %{io: io} do
+      # This is non-Unicode and shouldn't crash RingLogger. There are slightly
+      # different paths that are taken for iodata vs binary data, so make sure
+      # they behave identically.
+      message_string = <<227, 97, 195, 253, 123, 50, 91, 116, 114, 227, 110>>
+      message_iodata = [message_string]
 
-    :ok = RingLogger.attach(io: io)
-    Logger.debug(message_string)
-    assert_receive {:io, message_string_result}
+      :ok = RingLogger.attach(io: io)
+      Logger.debug(message_string)
+      assert_receive {:io, message_string_result}
 
-    Logger.debug(message)
-    assert_receive {:io, message_result}
+      Logger.debug(message_iodata)
+      assert_receive {:io, message_iodata_result}
 
-    assert message_result == message_string_result
-    assert message_result =~ "{2[tr"
+      assert String.valid?(message_string_result)
+      assert String.valid?(message_iodata_result)
+
+      assert message_string_result =~ "{2[tr"
+      assert message_iodata_result =~ "{2[tr"
+    end
   end
 
   test "logging totally wrong data doesn't crash", %{io: io} do


### PR DESCRIPTION
OTP 28's ssh server no longer handles non-Unicode I/O. This historically
was used to avoid garbled log messages from raising exceptions. Maybe
OTP 28 should still support this, but it seems much better just to
replace the garbled output with printable characters to avoid messing up
a user's terminal session on accident.

This means that all I/O needs to go through IO.write.
