### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Hex version](https://img.shields.io/hexpm/v/ring_logger.svg "Hex version")](https://hex.pm/packages/ring_logger)
 
 This is an in-memory ring buffer backend for the [Elixir
-Logger](https://hexdocs.pm/logger/Logger.html) with convenience methods for
+Logger](https://logger.hexdocs.pm/Logger.html) with convenience methods for
 accessing the logs from the IEx prompt.
 
 Use cases:
@@ -262,7 +262,7 @@ Important message! iex:4
 
 Within an application, the `iex:4` would be the source file path and line number.
 
-See [Logger custom formatting](https://hexdocs.pm/logger/Logger.html#module-custom-formatting)
+See [Logger custom formatting](https://logger.hexdocs.pm/Logger.html#module-custom-formatting)
 for more information.
 
 ## Programmatic usage

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -55,7 +55,7 @@ defmodule RingLogger.Client do
   * `:colors` -
   * `:metadata` - A KV list of additional metadata
   * `:format` - A custom format string, or a {module, function} tuple (see
-    https://hexdocs.pm/logger/master/Logger.html#module-custom-formatting)
+    https://logger.hexdocs.pm/master/Logger.html#module-custom-formatting)
   * `:level` - The minimum log level to report.
   * `:module_levels` - a map of log level overrides per module. For example,
     %{MyModule => :error, MyOtherModule => :none}


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://logger.hexdocs.pm/Logger.html): Status 404
❌ Verification failed for https://logger.hexdocs.pm/master/Logger.html#module-custom-formatting): %Req.HTTPError{protocol: :http2, reason: :pool_not_available}
⚠️ Verification finished: 1 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>