### PR TITLE
Bump CI versions to avoid OTP 27 TLS issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ latest: &latest
 tags: &tags
   [
     1.20.2-erlang-29.0.3-alpine-3.24.1,
-    1.19.1-erlang-28.1.1-alpine-3.22.2,
-    1.18.3-erlang-27.3.4-alpine-3.21.3,
-    1.17.3-erlang-27.2.1-alpine-3.20.5,
-    1.16.3-erlang-26.2.5-alpine-3.19.1,
-    1.15.7-erlang-26.2.4-alpine-3.18.6,
-    1.14.5-erlang-25.3.2.11-alpine-3.17.7,
+    1.19.5-erlang-28.5.0.3-alpine-3.24.1,
+    1.18.4-erlang-27.3.4.14-alpine-3.24.1,
+    1.17.3-erlang-27.3.4.14-alpine-3.24.1,
+    1.16.3-erlang-26.2.5.21-alpine-3.24.1,
+    1.15.8-erlang-26.2.5.21-alpine-3.24.1,
+    1.14.5-erlang-25.3.2.21-alpine-3.22.5,
     1.13.4-erlang-24.3.4.17-alpine-3.16.9
   ]
 


### PR DESCRIPTION
This also bumps the others to the latest.
