### PR TITLE
Normalize deprecated :warn log level to :warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Changes
   * Support passing initial commands to `RingLogger.viewer`. E.g., `Ringlogger.viewer("a application1")`
+  * Normalize the deprecated `:warn` log level to `:warning` when storing log
+    entries, loading persisted logs, and reading configuration. The
+    `logger_backends` translation layer still delivers warnings to backends as
+    `:warn`, which caused Elixir 1.20's `Logger.compare_levels/2` to emit
+    "the log level :warn is deprecated" warnings whenever the viewer's level
+    filter ran. Legacy `:warn` config (colors, `:level`, `:module_levels`,
+    `:application_levels`, per-level buffers) is still accepted.
 
 ## v0.11.5
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ Also, it allows for filtering the whole project on a higher level, but a
 particular module, or a subset of modules, to log at a lower level like so:
 
 ```elixir
-iex> RingLogger.attach(module_levels: %{MyModule => :debug}, level: :warn)
+iex> RingLogger.attach(module_levels: %{MyModule => :debug}, level: :warning)
 ```
 
 In the example above log messages at the `:debug` level will be logged, but
-every other module will be logging at the `:warn` level. You can also turn off a
+every other module will be logging at the `:warning` level. You can also turn off a
 module's logging completely by specifying `:none`.
 
 Additionally, you can specify the same options at the application level to

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -405,16 +405,23 @@ defmodule RingLogger.Client do
     {:format, configure_formatter(format)}
   end
 
+  defp configure_option({:level, level}) do
+    {:level, normalize_level(level)}
+  end
+
   defp configure_option(opt), do: opt
 
   defp configure_metadata(:all), do: :all
   defp configure_metadata(metadata), do: Enum.reverse(metadata)
 
   defp configure_colors(colors) when is_list(colors) do
+    warning_color = Keyword.get(colors, :warning, Keyword.get(colors, :warn, :yellow))
+
     %{
       debug: Keyword.get(colors, :debug, :cyan),
       info: Keyword.get(colors, :info, :normal),
-      warn: Keyword.get(colors, :warn, :yellow),
+      warn: warning_color,
+      warning: warning_color,
       error: Keyword.get(colors, :error, :red),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
     }
@@ -441,6 +448,11 @@ defmodule RingLogger.Client do
   defp meet_level?(_lvl, :none), do: false
   defp meet_level?(:warn, min), do: Logger.compare_levels(:warning, min) != :lt
   defp meet_level?(lvl, min), do: Logger.compare_levels(lvl, min) != :lt
+
+  # Elixir's Logger deprecated :warn in favor of :warning. Accept :warn from
+  # legacy configuration, but only compare with current level atoms.
+  defp normalize_level(:warn), do: :warning
+  defp normalize_level(level), do: level
 
   defp take_metadata(metadata, :all), do: metadata
 
@@ -472,6 +484,7 @@ defmodule RingLogger.Client do
 
     Keyword.get(config, :application_levels, %{})
     |> Enum.reduce(module_levels, &add_module_levels_for_application/2)
+    |> Map.new(fn {module, level} -> {module, normalize_level(level)} end)
   end
 
   defp add_module_levels_for_application({app, level}, module_levels) do

--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -286,7 +286,7 @@ defmodule RingLogger.Server do
     index = state.index
 
     log_entry = %{
-      level: level,
+      level: normalize_level(level),
       module: module,
       message: message,
       timestamp: timestamp,
@@ -330,7 +330,7 @@ defmodule RingLogger.Server do
     Enum.map(buffers, fn {name, config} ->
       %Buffer{
         name: name,
-        levels: config[:levels],
+        levels: Enum.map(config[:levels], &normalize_level/1),
         max_size: config[:max_size],
         circular_buffer: CircularBuffer.new(config[:max_size])
       }
@@ -344,7 +344,12 @@ defmodule RingLogger.Server do
           logs
           |> Enum.with_index()
           |> Enum.reduce(state, fn {log_entry, index}, state ->
-            log_entry = %{log_entry | metadata: Keyword.put(log_entry.metadata, :index, index)}
+            log_entry = %{
+              log_entry
+              | level: normalize_level(log_entry.level),
+                metadata: Keyword.put(log_entry.metadata, :index, index)
+            }
+
             insert_log(state, log_entry)
           end)
 
@@ -358,7 +363,7 @@ defmodule RingLogger.Server do
           :calendar.system_time_to_universal_time(timestamp, :microsecond)
 
         log_entry = %{
-          level: :warn,
+          level: :warning,
           module: Logger,
           message: "RingLogger could not load the persistence file, it is corrupt",
           timestamp: {date, {hours, minutes, seconds, div(micro, 1000)}},
@@ -373,4 +378,10 @@ defmodule RingLogger.Server do
         state
     end
   end
+
+  # Elixir's Logger deprecated :warn in favor of :warning, but the
+  # logger_backends translation layer and old persisted log files still
+  # deliver :warn. Normalize so buffers only ever hold current level atoms.
+  defp normalize_level(:warn), do: :warning
+  defp normalize_level(level), do: level
 end

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -21,6 +21,11 @@ defmodule RingLogger.Client.Test do
       assert :error == :sys.get_state(client).level
     end
 
+    test "configure legacy :warn level is normalized to :warning", %{client: client} do
+      Client.configure(client, level: :warn)
+      assert :warning == :sys.get_state(client).level
+    end
+
     test "configure colors", %{client: client} do
       colors = %{
         debug: :red,
@@ -32,7 +37,16 @@ defmodule RingLogger.Client.Test do
 
       Client.configure(client, colors: colors)
 
-      assert colors == :sys.get_state(client).colors
+      # The legacy :warn color is used for both :warn and :warning entries
+      assert Map.put(colors, :warning, :cyan) == :sys.get_state(client).colors
+    end
+
+    test "configure colors with a :warning key", %{client: client} do
+      Client.configure(client, colors: %{warning: :magenta})
+
+      colors = :sys.get_state(client).colors
+      assert colors.warning == :magenta
+      assert colors.warn == :magenta
     end
 
     test "configure metadata", %{client: client} do
@@ -63,6 +77,12 @@ defmodule RingLogger.Client.Test do
       assert :sys.get_state(client).module_levels == module_levels
     end
 
+    test "configures module_levels with legacy :warn normalized to :warning", %{client: client} do
+      Client.configure(client, module_levels: %{RingLogger => :warn})
+
+      assert :sys.get_state(client).module_levels == %{RingLogger => :warning}
+    end
+
     test "configures module_levels from application_levels", %{client: client} do
       Client.configure(client, application_levels: %{ring_logger: :debug})
 
@@ -87,7 +107,14 @@ defmodule RingLogger.Client.Test do
 
   test "can retrieve configuration", %{client: client} do
     config = [
-      colors: %{debug: :cyan, enabled: true, error: :red, info: :normal, warn: :yellow},
+      colors: %{
+        debug: :cyan,
+        enabled: true,
+        error: :red,
+        info: :normal,
+        warn: :yellow,
+        warning: :yellow
+      },
       format: ["\n", :time, " ", :metadata, "[", :level, "] ", :message, "\n"],
       io: :stdio,
       level: :debug,

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -308,6 +308,24 @@ defmodule RingLoggerTest do
     assert [%{level: :debug, module: Logger, message: "Hello"}] = buffer
   end
 
+  test "warning messages are stored with the :warning level", %{io: io} do
+    :ok = RingLogger.attach(io: io)
+    handshake_log(io, :warning, "Hello")
+
+    buffer = RingLogger.get()
+    assert [%{level: :warning, module: Logger, message: "Hello"}] = buffer
+  end
+
+  test "legacy :warn events are normalized to :warning", %{io: io} do
+    :ok = RingLogger.attach(io: io)
+
+    # Simulate the :warn level that logger_backends delivers for warnings
+    RingLogger.Server.log(:warn, {Logger, "legacy warn", {{2023, 2, 8}, {13, 58, 31, 343}}, []})
+
+    buffer = RingLogger.get()
+    assert [%{level: :warning, module: Logger, message: "legacy warn"}] = buffer
+  end
+
   test "buffer does not exceed size", %{io: io} do
     Logger.configure_backend(RingLogger, max_size: 2)
     :ok = RingLogger.attach(io: io)
@@ -591,7 +609,14 @@ defmodule RingLoggerTest do
       :ok = RingLogger.attach(io: io)
 
       config = [
-        colors: %{debug: :cyan, enabled: true, error: :red, info: :normal, warn: :yellow},
+        colors: %{
+          debug: :cyan,
+          enabled: true,
+          error: :red,
+          info: :normal,
+          warn: :yellow,
+          warning: :yellow
+        },
         format: ["\n", :time, " ", :metadata, "[", :level, "] ", :message, "\n"],
         io: io,
         level: :debug,
@@ -621,6 +646,29 @@ defmodule RingLoggerTest do
       )
 
       :ok = RingLogger.attach(io: io)
+    end
+
+    test "buffers configured with legacy :warn capture :warning entries", %{io: io} do
+      Logger.configure_backend(RingLogger,
+        buffers: %{
+          warnings: %{
+            levels: [:warn],
+            max_size: 10
+          }
+        }
+      )
+
+      :ok = RingLogger.attach(io: io)
+
+      io = handshake_log(io, :warning, "wumbo")
+
+      # Flood the default buffer (max_size: 10) with debug messages. The
+      # warning entry must survive because it routes to the warnings buffer.
+      Enum.reduce(1..10, io, fn _, io -> handshake_log(io, :debug, "noise") end)
+
+      buffer = RingLogger.get(0, 0)
+
+      assert [%{level: :warning, message: "wumbo"} | _] = buffer
     end
 
     test "different levels use different buffers", %{io: io} do
@@ -750,6 +798,35 @@ defmodule RingLoggerTest do
   end
 
   describe "persistence" do
+    test "loading a log with legacy :warn entries normalizes them to :warning", %{io: io} do
+      Logger.remove_backend(RingLogger)
+
+      logs = [
+        %{
+          level: :warn,
+          module: Logger,
+          message: "Old warning",
+          timestamp: {{2023, 2, 8}, {13, 58, 31, 343}},
+          metadata: []
+        }
+      ]
+
+      :ok = Persistence.save("test/persistence.log", logs)
+
+      # Start the backend with _just_ the persist_path and restore old
+      # config to allow other tests to run without loading a log file
+      old_env = Application.get_env(:logger, RingLogger)
+      Application.put_env(:logger, RingLogger, persist_path: "test/persistence.log")
+      Logger.add_backend(RingLogger)
+      Application.put_env(:logger, RingLogger, old_env)
+
+      :ok = RingLogger.attach(io: io)
+
+      assert [%{level: :warning, message: "Old warning"}] = RingLogger.get(0, 0)
+
+      File.rm!("test/persistence.log")
+    end
+
     test "loading the log", %{io: io} do
       Logger.remove_backend(RingLogger)
 


### PR DESCRIPTION
This PR is only relevant for as long as RingLogger uses the backwards compatible LoggerBackends library. Another, cleaner solution would be to refactor RingLogger to be a custom "event handler" as per Elixir >= 1.15 but that would be a much heavier lift.

As per [José](https://github.com/elixir-lang/logger_backends/commit/947b72eb0fc8b0b3ea163110d1e8fb9d5b1c2d80),
```
"""
  ## Levels

  For backwards compatibility purposes, a Logger Backend receives only `:debug`,
  `:info`, `:warn`, and `:error` as log levels. In particular, notice you will
  need to convert `:warn` to `:warning` if you plan to use the `Logger` functions.
"""
```

And, [José's](https://github.com/elixir-lang/logger_backends/pull/8#issuecomment-2651970940), response when asked about changing Logger to use :warning instead of :warn.
> This would be a backwards incompatible change, as previous versions did return :warn. My suggestion is to convert from warn to warning in your own backends.

Which is essentially what this PR does.

## LoggerBackends :warn source
To maintain backwards compatibility, `logger_backends` translates received `:warning` to `:warn` before handing events to gen_event backends ([handler.ex:120](https://github.com/elixir-lang/logger_backends/blob/v1.0.1/lib/logger_backends/handler.ex#L120)), so every buffered :warning entry carries the deprecated :warn atom. 

On Elixir 1.20 the RingLogger.Viewer's level filter feeds that into `Logger.compare_levels/2`, which warns once per buffered entry per filter pass:

```
warning: the log level :warn is deprecated, use :warning instead
  (ring_logger 0.11.5) lib/ring_logger/viewer.ex:323: RingLogger.Viewer.maybe_apply_level_filter?/2
```

## Additional :warn sources
Two more sources of `:warn` inside ring_logger itself: the corrupt-persistence-file entry was hardcoded to `:warn`, and old persisted log files on disk still contain it.

## Solution
Fortunately, LoggerBackends includes the original reported levels in the metadata which means the LoggerBackend transformation of :warning to :warn, is reversible in RingLogger. 

This PR takes the deprecated but backwards compatible LoggerBackend :warn levels and converts them all to :warning on ingestion. It also performs the conversion at other I/O boundaries.

**Fix:** normalize `:warn` -> `:warning` everywhere a level enters the buffer or config 
- server ingest, 
- persisted logs, 
- the corrupt-file entry, 
- per-level buffer config, 
- client `:level`/`:module_levels`/`:application_levels`/colors. 
- Legacy `:warn` from other apps and existing config is still accepted, just mapped through.


**Tests:**
- `mix test --warnings-as-errors`, `mix format --check-formatted`, `mix credo -a --strict`, `mix dialyzer` all pass
- New tests cover 
  - `:warn` ingestion normalization 
  - persisted `:warn` entries 
  - legacy `[:warn]` buffer routing
  - legacy client config
- Verified against Fellowes `blofeld_iot_firmware` on host with Elixir 1.20.2/OTP 29, 
  - before, buffer held `%{error: 1, warn: 2}` with a deprecation warning per entry
  - after, `%{error: 1, warning: 2}`, no deprecation warnings

Above was mostly written by me.

Assisted-by: Claude Code:claude-opus-5