### PR TITLE
Update Elixir 1.17 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ tags: &tags
     1.20.2-erlang-29.0.3-alpine-3.24.1,
     1.19.5-erlang-28.5.0.3-alpine-3.24.1,
     1.18.4-erlang-27.3.4.14-alpine-3.24.1,
-    1.17.3-erlang-27.3.4.14-alpine-3.24.1,
+    1.17.3-erlang-27.3.4.16-alpine-3.24.1,
     1.16.3-erlang-26.2.5.21-alpine-3.24.1,
     1.15.8-erlang-26.2.5.21-alpine-3.24.1,
     1.14.5-erlang-25.3.2.21-alpine-3.22.5,


### PR DESCRIPTION
Update the Elixir 1.17 CircleCI image to OTP 27.3.4.16 and Alpine 3.24.1. This avoids an OTP 27 bug that is causing CI failures.